### PR TITLE
Cubism 4 SDK for Java R1 beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4-r.1-beta.2] - 2023-01-26
+
+### Changed
+
+* Change Android SDK API level from 31 (Android 12) to 33 (Android 13).
+* Change the import statement of `LAppDefine` class to reflect the changes in CubismFramework.
+* Change the processing where `getMotionMap` function in `CubismModelSettingJson` was used.
+* Change setup code of a renderer in `loadAssets` function in `LAppModel` and `LAppMinimumModel` classes to match CubismFramework changes.
+* Change the key type of Map used in `setupModel` function in `LAppModel` and `LAppMinimumModel` that store model layout information to match the CubismFramework changes.
+
+### Fixed
+
+* Fix `onDestroy` function in `LAppDelegate` and `LAppMinimumDelegate` to release a singleton instance.
+
+### Removed
+
+* Remove dependencies not to be used.
+* Remove unnecessary commenting lines.
+* Remove unused variables defined in `startMotion` function of `LAppModel` and `LAppMinimumModel` classes.
+
 ## [4-r.1-beta.1] - 2022-12-08
 
 ### Fixed
@@ -18,4 +38,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * New released!
 
+[4-r.1-beta.2]: https://github.com/Live2D/CubismJavaSamples/compare/4-r.1-beta.1...4-r.1-beta.2
 [4-r.1-beta.1]: https://github.com/Live2D/CubismJavaSamples/compare/4-r.1-alpha.1...4-r.1-beta.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,8 +59,8 @@ Android Studioでプロジェクトを開きビルドすることを推奨しま
 
 | 開発ツール          | バージョン            |
 |----------------|------------------|
-| Android Studio | Dolphin 2021.3.1 Patch 1 |
-| IntelliJ IDEA  | 2022.1.4         |
+| Android Studio | Electric Eel 2022.1.1 |
+| IntelliJ IDEA  | 2022.3.1         |
 | CMake          | 3.1.0            |
 | Gradle         | 6.9              |
 
@@ -69,7 +69,7 @@ Android Studioでプロジェクトを開きビルドすることを推奨しま
 | Android SDK tools | バージョン        |
 | --- |--------------|
 | Android NDK | 21.4.7075529 |
-| Android SDK | 31.0.0       |
+| Android SDK | 33.0.0       |
 | CMake | 3.1.0        |
 
 ## 動作確認環境
@@ -79,11 +79,11 @@ Android Studioでプロジェクトを開きビルドすることを推奨しま
 本サンプルアプリケーションは**Java SE 6**以上のJavaバージョンで動作します。
 
 ### Android
-| バージョン | デバイス              | Tegra |
-|-------|-------------------|-------|
-| 12    | Redmi Note 10 Pro |  |
-| 7.1.1 | Nexus 9           | ✔ |
-| 4.1   | Pixel 5          |  |
+| バージョン | デバイス     | Tegra |
+|-------|----------|-------|
+| 13    | Pixel 6a |  |
+| 7.1.1 | Nexus 9  | ✔ |
+| 4.1   | Pixel 5  |  |
 
 本サンプルアプリケーションは**Android API 16**以上のAndroidバージョンで動作します。
 

--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ Please refer to [CHANGELOG.md](CHANGELOG.md) for the changelog of this repositor
 
 ## Development environment
 
-| Development Tools | Version          |
-|-------------------|------------------|
-| Android Studio    | Dolphin 2021.3.1 Patch 1 |
-| IntelliJ IDEA     | 2022.3           |
-| CMake             | 3.1.0            |
-| Gradle            | 6.9              |
+| Development Tools | Version |
+|-------------------|--|
+| Android Studio    | Electric Eel 2022.1.1 |
+| IntelliJ IDEA     | 2022.3.1 |
+| CMake             | 3.1.0 |
+| Gradle            | 6.9 |
 
 ### Android
 
 | Android SDK tools | Version      |
 | --- |--------------|
 | Android NDK | 21.4.7075529 |
-| Android SDK | 31.0.0       |
+| Android SDK | 33.0.0       |
 | CMake | 3.1.0        |
 
 ## Operation environment
@@ -80,11 +80,11 @@ This sample application runs with **Java SE 6** or higher Java versions.
 
 ### Android
 
-| Version | Device            | Tegra |
-|---------|-------------------| --- |
-| 12      | Redmi Note 10 Pro ||
-| 7.1.1   | Nexus 9           | ✔︎ |
-| 4.1   | Pixel 5           ||
+| Version | Device   | Tegra |
+|---------|----------| --- |
+| 13      | Pixel 6a ||
+| 7.1.1   | Nexus 9  | ✔︎ |
+| 4.1   | Pixel 5  ||
 
 This sample application runs with **Android API 16** or higher Android versions.
 

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -65,8 +65,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
 
-    testImplementation 'junit:junit:4.13.2'
-
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 

--- a/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
@@ -25,6 +25,15 @@ public class LAppDelegate {
     }
 
     /**
+     * クラスのインスタンス（シングルトン）を解放する。
+     */
+    public static void releaseInstance() {
+        if (s_instance != null) {
+            s_instance = null;
+        }
+    }
+
+    /**
      * アプリケーションを非アクティブにする
      */
     public void deactivateApp() {
@@ -53,7 +62,7 @@ public class LAppDelegate {
     }
 
     public void onDestroy() {
-        // TODO: インスタンスのリリース
+        releaseInstance();
     }
 
     public void onSurfaceCreated() {
@@ -172,8 +181,6 @@ public class LAppDelegate {
 
         GLES20.glShaderSource(fragmentShaderId, fragmentShader);
         GLES20.glCompileShader(fragmentShaderId);
-
-        // TODO: コンパイルエラーをチェックするコードを入れる
 
         // プログラムオブジェクトの作成
         int programId = GLES20.glCreateProgram();

--- a/Sample/src/full/java/com/live2d/demo/full/LAppLive2DManager.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppLive2DManager.java
@@ -123,8 +123,6 @@ public class LAppLive2DManager {
                 }
 
                 model.startRandomMotion(MotionGroup.TAP_BODY.getId(), Priority.NORMAL.getPriority(), finishedMotion);
-
-                // play sound file
             }
         }
     }
@@ -164,22 +162,6 @@ public class LAppLive2DManager {
          * ここでUSE_RENDER_TARGET、USE_MODEL_RENDER_TARGETが定義されている場合
          * 別のレンダリングターゲットにモデルを描画し、描画結果をテクスチャとして別のスプライトに張り付ける。
          */
-//        LAppView.RenderingTarget useRenderingTarget;
-//        switch(LAppDelegate.getInstance().getView().getRenderingTarget()){
-//            case NONE:
-//                useRenderingTarget = LAppView.RenderingTarget.NONE;
-//                break;
-//            case MODEL_FRAME_BUFFER:
-//                // 各LAppModelの持つターゲットに描画を行う場合こちらを選択
-//                useRenderingTarget = LAppView.RenderingTarget.MODEL_FRAME_BUFFER;
-//                break;
-//            case VIEW_FRAME_BUFFER:
-//                // 各LAppViewの持つターゲットに描画を行う場合こちらを選択
-//                useRenderingTarget = LAppView.RenderingTarget.VIEW_FRAME_BUFFER;
-//                break;
-//            default:
-//                useRenderingTarget = LAppView.RenderingTarget.NONE;
-//        }
         LAppView.RenderingTarget useRenderingTarget;
         if (USE_RENDER_TARGET) {
             // LAppViewの持つターゲットに描画を行う場合こちらを選択

--- a/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
@@ -22,9 +22,9 @@ import com.live2d.sdk.cubism.framework.motion.ACubismMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
+import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismOffscreenSurfaceAndroid;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismRendererAndroid;
-import com.live2d.sdk.cubism.framework.utils.jsonparser.CubismJsonString;
 
 import java.util.*;
 
@@ -65,7 +65,10 @@ public class LAppModel extends CubismUserModel {
             return;
         }
 
-        createRenderer(RendererType.ANDROID);
+        // Setup renderer.
+        CubismRenderer renderer = CubismRendererAndroid.create();
+        setupRenderer(renderer);
+
         setupTextures();
     }
 
@@ -200,7 +203,6 @@ public class LAppModel extends CubismUserModel {
         String name = group + "_" + number;
 
         CubismMotion motion = (CubismMotion) motions.get(name);
-        boolean isAutoDelete = false;
 
         if (motion == null) {
             String fileName = modelSetting.getMotionFileName(group, number);
@@ -224,7 +226,6 @@ public class LAppModel extends CubismUserModel {
                     }
 
                     motion.setEffectIds(eyeBlinkIds, lipSyncIds);
-                    isAutoDelete = true;    // 終了時にメモリから削除
                 }
             }
         } else {
@@ -476,7 +477,7 @@ public class LAppModel extends CubismUserModel {
         }
 
         // Set layout
-        Map<CubismJsonString, Float> layout = new HashMap<CubismJsonString, Float>();
+        Map<String, Float> layout = new HashMap<String, Float>();
 
         // レイアウト情報が存在すればその情報からモデル行列をセットアップする
         if (modelSetting.getLayoutMap(layout)) {
@@ -632,6 +633,4 @@ public class LAppModel extends CubismUserModel {
      * フレームバッファ以外の描画先
      */
     private final CubismOffscreenSurfaceAndroid renderingBuffer = new CubismOffscreenSurfaceAndroid();
-
-
 }

--- a/Sample/src/full/java/com/live2d/demo/full/LAppView.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppView.java
@@ -44,9 +44,7 @@ public class LAppView {
         float ratio = (float) width / (float) height;
         float left = -ratio;
         float right = ratio;
-//        float bottom = VIEW_LOGICAL_LEFT;
         float bottom = LogicalView.LEFT.getValue();
-//        float top = VIEW_LOGICAL_RIGHT;
         float top = LogicalView.RIGHT.getValue();
 
         // デバイスに対応する画面範囲。Xの左端、Xの右端、Yの下端、Yの上端

--- a/Sample/src/main/java/com/live2d/demo/LAppDefine.java
+++ b/Sample/src/main/java/com/live2d/demo/LAppDefine.java
@@ -7,8 +7,7 @@
 
 package com.live2d.demo;
 
-
-import com.live2d.sdk.cubism.framework.CubismFramework;
+import com.live2d.sdk.cubism.framework.CubismFrameworkConfig.LogLevel;
 
 /**
  * Constants used in this sample app.
@@ -241,7 +240,7 @@ public class LAppDefine {
     /**
      * Setting the level of the log output from the Framework.
      */
-    public static final CubismFramework.Option.LogLevel cubismLoggingLevel = CubismFramework.Option.LogLevel.VERBOSE;
+    public static final LogLevel cubismLoggingLevel = LogLevel.VERBOSE;
     /**
      * Enable/Disable premultiplied alpha.
      */

--- a/Sample/src/main/java/com/live2d/demo/TouchManager.java
+++ b/Sample/src/main/java/com/live2d/demo/TouchManager.java
@@ -229,7 +229,6 @@ public class TouchManager {
     private boolean isTouchSingle;
     /**
      * フリップが有効かどうか
-     * // TODO: フリックの間違い？
      */
     private boolean isFlipAvailable;
 }

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumDelegate.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumDelegate.java
@@ -24,6 +24,15 @@ public class LAppMinimumDelegate {
         return s_instance;
     }
 
+    /**
+     * クラスのインスタンス（シングルトン）を解放する。
+     */
+    public static void releaseInstance() {
+        if (s_instance != null) {
+            s_instance = null;
+        }
+    }
+
     public void onStart(Activity activity) {
         textureManager = new LAppMinimumTextureManager();
         view = new LAppMinimumView();
@@ -45,7 +54,7 @@ public class LAppMinimumDelegate {
     }
 
     public void onDestroy() {
-
+        releaseInstance();
     }
 
     public void onSurfaceCreated() {
@@ -151,7 +160,6 @@ public class LAppMinimumDelegate {
                 "varying vec2 vuv;" +
                 "uniform vec4 baseColor;" +
                 "void main(void){" +
-//                        "gl_FragColor = texture2D(texture, vuv) * baseColor;" +
                 "gl_FragColor = texture2D(texture, vuv);" +
                 "}";
 

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumModel.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumModel.java
@@ -20,10 +20,9 @@ import com.live2d.sdk.cubism.framework.motion.ACubismMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
+import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismOffscreenSurfaceAndroid;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismRendererAndroid;
-import com.live2d.sdk.cubism.framework.utils.jsonparser.CubismJsonString;
-import com.live2d.sdk.cubism.framework.utils.jsonparser.ACubismJsonValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,7 +49,11 @@ public class LAppMinimumModel extends CubismUserModel {
 
         // Setup model
         setupModel(filePath);
-        createRenderer(RendererType.ANDROID);
+
+        // Setup renderer.
+        CubismRenderer renderer = CubismRendererAndroid.create();
+        setupRenderer(renderer);
+
         setupTextures();
     }
 
@@ -125,7 +128,6 @@ public class LAppMinimumModel extends CubismUserModel {
         }
 
         // Physics Setting
-//        _physics.ifPresent(p -> p.evaluate(_model, deltaTimeSeconds));
         if (physics != null) {
             physics.evaluate(model, deltaTimeSeconds);
         }
@@ -181,7 +183,6 @@ public class LAppMinimumModel extends CubismUserModel {
         String name = group + "_" + number;
 
         CubismMotion motion = (CubismMotion) motions.get(name);
-        boolean isAutoDelete = false;
 
         if (motion == null) {
             if (fileName.equals("")) {
@@ -203,8 +204,6 @@ public class LAppMinimumModel extends CubismUserModel {
                     if (fadeOutTime != -1.0f) {
                         motion.setFadeOutTime(fadeOutTime);
                     }
-
-                    isAutoDelete = true;    // 終了時にメモリから削除
                 }
             }
         } else {
@@ -318,7 +317,7 @@ public class LAppMinimumModel extends CubismUserModel {
 
 
         // Set layout
-        Map<CubismJsonString, Float> layout = new HashMap<CubismJsonString, Float>();
+        Map<String, Float> layout = new HashMap<String, Float>();
         this.modelSetting.getLayoutMap(layout);
 
         // If layout information exists, the model matrix is set up from it.
@@ -329,9 +328,8 @@ public class LAppMinimumModel extends CubismUserModel {
         model.saveParameters();
 
         // Load motions
-        Map<CubismJsonString, ACubismJsonValue> map = this.modelSetting.getMotionMap();
-        for (Map.Entry<CubismJsonString, ACubismJsonValue> entry : map.entrySet()) {
-            final String group = entry.getKey().getString();
+        for (int i = 0; i < modelSetting.getMotionGroupCount(); i++) {
+            String group = modelSetting.getMotionGroupName(i);
             preLoadMotionGroup(group);
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,11 +19,11 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Added later
 # Android SDK version that will be used as the compiled project
-PROP_COMPILE_SDK_VERSION=31
+PROP_COMPILE_SDK_VERSION=33
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=16
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=31
+PROP_TARGET_SDK_VERSION=33
 # List of CPU Archtexture to build that application with
 # Available architextures (armeabi-v7a | arm64-v8a | x86)
 # To build for multiple architexture, use the `:` between them


### PR DESCRIPTION
### Changed

* Change Android SDK API level from 31 (Android 12) to 33 (Android 13).
* Change the import statement of `LAppDefine` class to reflect the changes in CubismFramework.
* Change the processing where `getMotionMap` function in `CubismModelSettingJson` was used.
* Change setup code of a renderer in `loadAssets` function in `LAppModel` and `LAppMinimumModel` classes to match CubismFramework changes.
* Change the key type of Map used in `setupModel` function in `LAppModel` and `LAppMinimumModel` that store model layout information to match the CubismFramework changes.

### Fixed

* Fix `onDestroy` function in `LAppDelegate` and `LAppMinimumDelegate` to release a singleton instance.

### Removed

* Remove dependencies not to be used.
* Remove unnecessary commenting lines.
* Remove unused variables defined in `startMotion` function of `LAppModel` and `LAppMinimumModel` classes.