### PR TITLE
Update to Cubism 5 SDK for Java R1 beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5-r.1-beta.3] - 2024-01-18
+
+### Changed
+
+* Change the compile and target SDK version of Android OS to 14.0 (API 34).
+  * Upgrade the version of Android Gradle Plugin from 8.0.2 to 8.1.1.
+  * Upgrade the version of Gradle from 8.1.1 to 8.2.
+  * Change the minimum version of Android Studio to Hedgehog(2023.1.1).
+
+### Fixed
+
+* Fix a problem where the result loaded exp3.json is put into map even if it was null.
+* Replace deprecated notation in `build.gradle` and `AndroidManifest.xml`.
+
+
 ## [5-r.1-beta.2] - 2023-09-28
 
 ### Changed
@@ -99,6 +114,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * New released!
 
+[5-r.1-beta.3]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.2...5-r.1-beta.3
 [5-r.1-beta.2]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.1...5-r.1-beta.2
 [5-r.1-beta.1]: https://github.com/Live2D/CubismJavaSamples/compare/4-r.1...5-r.1-beta.1
 [4-r.1]: https://github.com/Live2D/CubismJavaSamples/compare/4-r.1-beta.4...4-r.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,16 +67,16 @@ Android Studioでプロジェクトを開きビルドすることを推奨しま
 
 | 開発ツール          | バージョン            |
 |----------------|------------------|
-| Android Studio | Giraffe 2022.3.1 |
+| Android Studio | Hedgehog 2023.1.1 |
 | CMake          | 3.1.0            |
-| Gradle         | 8.1.1              |
+| Gradle         | 8.2           |
 
 ### Android
 
 | Android SDK tools | バージョン        |
 | --- |--------------|
 | Android NDK | 21.4.7075529 |
-| Android SDK | 33.0.0       |
+| Android SDK | 34.0.0       |
 | CMake | 3.1.0        |
 
 ## 動作確認環境
@@ -88,7 +88,7 @@ Android Studioでプロジェクトを開きビルドすることを推奨しま
 ### Android
 | バージョン | デバイス     | Tegra |
 |-------|----------|-------|
-| 13    | Pixel 7a |  |
+| 14   | Pixel 7a |  |
 | 7.1.1 | Nexus 9  | ✔ |
 | 4.1   | Pixel 5  |  |
 

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ Please refer to [CHANGELOG.md](CHANGELOG.md) for the changelog of this repositor
 
 | Development Tools | Version |
 |-------------------|--|
-| Android Studio    | Giraffe 2022.3.1 |
+| Android Studio    | Hedgehog 2023.1.1 |
 | CMake             | 3.1.0 |
-| Gradle            | 8.1.1 |
+| Gradle            | 8.2 |
 
 ### Android
 
 | Android SDK tools | Version      |
 | --- |--------------|
 | Android NDK | 21.4.7075529 |
-| Android SDK | 33.0.0       |
+| Android SDK | 34.0.0       |
 | CMake | 3.1.0        |
 
 ## Operation environment
@@ -89,7 +89,7 @@ This sample application runs with **Java SE 7** or higher Java versions.
 
 | Version | Device   | Tegra |
 |---------|----------| --- |
-| 13      | Pixel 7a ||
+| 14     | Pixel 7a ||
 | 7.1.1   | Nexus 9  | ✔︎ |
 | 4.1   | Pixel 5  ||
 

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.live2d.demo"
-    compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
+    compileSdk PROP_COMPILE_SDK_VERSION.toInteger()
 
     defaultConfig {
         applicationId "com.live2d.demo"
@@ -40,7 +40,7 @@ android {
         }
     }
 
-    flavorDimensions "mode"
+    flavorDimensions = ["mode"]
     productFlavors {
         Full {
             dimension = "mode"
@@ -56,8 +56,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
-
-    lintOptions {
+    lint {
         abortOnError false
     }
 }

--- a/Sample/src/full/AndroidManifest.xml
+++ b/Sample/src/full/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.live2d.demo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-feature
     android:glEsVersion="0x00020000"

--- a/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
@@ -447,7 +447,9 @@ public class LAppModel extends CubismUserModel {
                     byte[] buffer = createBuffer(path);
                     CubismExpressionMotion motion = loadExpression(buffer);
 
-                    expressions.put(name, motion);
+                    if (motion != null) {
+                        expressions.put(name, motion);
+                    }
                 }
             }
         }

--- a/Sample/src/main/AndroidManifest.xml
+++ b/Sample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.live2d.demo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-feature
     android:glEsVersion="0x00020000"

--- a/Sample/src/minimum/AndroidManifest.xml
+++ b/Sample/src/minimum/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.live2d.demo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-feature
     android:glEsVersion="0x00020000"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.1'
 //        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,11 +19,11 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Added later
 # Android SDK version that will be used as the compiled project
-PROP_COMPILE_SDK_VERSION=33
+PROP_COMPILE_SDK_VERSION=34
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=33
+PROP_TARGET_SDK_VERSION=34
 # List of CPU Archtexture to build that application with
 # Available architextures (armeabi-v7a | arm64-v8a | x86)
 # To build for multiple architexture, use the `:` between them

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 11 17:28:23 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Changed

* Change the compile and target SDK version of Android OS to 14.0 (API 34).
  * Upgrade the version of Android Gradle Plugin from 8.0.2 to 8.1.1.
  * Upgrade the version of Gradle from 8.1.1 to 8.2.
  * Change the minimum version of Android Studio to Hedgehog(2023.1.1).

### Fixed

* Fix a problem where the result loaded exp3.json is put into map even if it was null.
* Replace deprecated notation in `build.gradle` and `AndroidManifest.xml`.