### PR TITLE
Update to Cubism 5 SDK for Java R2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## [5-r.2] - 2024-11-07
+
+### Added
+
+* Add a function to notify when motion playback starts.
+* Add right orientation to the fixed orientations in the Android app.
+* Add a feature to change render target to the minimum sample.
+
+### Fixed
+
+* Fix a hang-up caused by an improper function call in the application termination process.
+* Fix a bug that caused white edge-like objects to be drawn when enabling the `USE_RENDER_TARGET` or `USE_MODEL_RENDER_TARGET` flag in `LAppDefine`.
+* Fix a bug where the method of obtaining color location differs between full sample and minimum sample.
+
+### Removed
+
+* Remove armeabi-v7a from architecture support.
+* Remove the `startMotion()` method that receives a callback in the minimum sample.
+  * If you want to use the callback feature, please check the Full sample.
+
+
 ## [5-r.1] - 2024-03-26
 
 ### Added
@@ -140,6 +162,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * New released!
 
 
+[5-r.2]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.3...5-r.1
 [5-r.1-beta.3]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.2...5-r.1-beta.3
 [5-r.1-beta.2]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.1...5-r.1-beta.2

--- a/Core/CHANGELOG.md
+++ b/Core/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2024-11-07
+
+### Added
+
+* [Native] Add experimental support `arm64` library for linux.
+
+### Removed
+
+* [Unity,Native,Java] Remove Android ARM v7 library.
+
+
+## 2024-04-04
+
+### Added
+
+* [Unity] Add library(.so) for HarmonyOS build.
+
+
 ## 2024-03-26
 
 ### Remove

--- a/Core/README.ja.md
+++ b/Core/README.ja.md
@@ -18,6 +18,5 @@ Javaで開発する場合は、このファイルを使用してください。
 | プラットフォーム | アーキテクチャ  | jar | aar | パス | 注記  |
 | --- |----------|---|-----|---|-----|
 | Android | ARM64    |   | ✓ | android/Live2DCubismCore.aar |     |
-| Android | ARMv7    |   | ✓ | android/Live2DCubismCore.aar | このライブラリは現在非推奨で、近日中に削除される予定です。 |
 | Android | x86      |   | ✓ | android/Live2DCubismCore.aar |     |
 | Android | x86_64   |   | ✓ | android/Live2DCubismCore.aar |     |

--- a/Core/README.md
+++ b/Core/README.md
@@ -18,6 +18,5 @@ Use this file when developing with Java.
 | Platform | Architecture | jar | aar | Path                         | Note |
 | --- | --- | --- | --- |------------------------------| --- |
 | Android | ARM64 |  |✓  | android/Live2DCubismCore.aar |    |
-| Android | ARMv7 |  | ✓ | android/Live2DCubismCore.aar | This library is currently deprecated and will be removed in the near future. |
 | Android | x86 |  | ✓ | android/Live2DCubismCore.aar |    |
 | Android | x86_64 |  | ✓ | android/Live2DCubismCore.aar |    |

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,8 +71,9 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | 開発ツール          | バージョン            |
 |----------------|------------------|
-| Android Studio | Iguana 2023.2.1 |
+| Android Studio | Ladybug 2024.2.1 Patch 2 |
 | Gradle         | 8.2           |
+| Gradle JDK | 17.0.12 |
 | Android SDK | 34.0.0       |
 
 ## 動作確認環境
@@ -82,11 +83,11 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 本サンプルアプリケーションは**Java SE 7**以上のJavaバージョンで動作します。
 
 ### Android
-| バージョン | デバイス     | Tegra |
-|-------|----------|-------|
-| 14   | Pixel 7a |  |
-| 7.1.1 | Nexus 9  | ✔ |
-| 4.1   | Pixel 5  |  |
+
+| バージョン | デバイス     | エミュレーター |
+|-------|----------|:-------:|
+| 14    | Pixel 7a |         |
+| 5.0   | Pixel 7a |    ✔    |
 
 本サンプルアプリケーションは**Android API 21**以上のAndroidバージョンで動作します。
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | Development Tools | Version |
 |-------------------|--|
-| Android Studio    | Iguana 2023.2.1 |
+| Android Studio    | Ladybug 2024.2.1 Patch 2 |
 | Gradle            | 8.2 |
+| Gradle JDK | 17.0.12 |
 | Android SDK | 34.0.0       |
 
 ## Operation environment
@@ -83,11 +84,10 @@ This sample application runs with **Java SE 7** or higher Java versions.
 
 ### Android
 
-| Version | Device   | Tegra |
-|---------|----------| --- |
-| 14     | Pixel 7a ||
-| 7.1.1   | Nexus 9  | ✔︎ |
-| 4.1   | Pixel 5  ||
+| Version | Device   | Emulator |
+|---------|----------|:--------:|
+| 14      | Pixel 7a |          |
+| 5.0     | Pixel 7a |    ✔     |
 
 This sample application runs with **Android API 21** or higher Android versions.
 

--- a/Sample/src/full/AndroidManifest.xml
+++ b/Sample/src/full/AndroidManifest.xml
@@ -15,7 +15,7 @@
     <activity
       android:name=".full.MainActivity"
       android:configChanges="orientation|screenSize"
-      android:screenOrientation="landscape"
+      android:screenOrientation="sensorLandscape"
       android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
@@ -113,7 +113,6 @@ public class LAppDelegate {
         // アプリケーションを非アクティブにする
         if (!isActive) {
             activity.finishAndRemoveTask();
-            System.exit(0);
         }
     }
 

--- a/Sample/src/full/java/com/live2d/demo/full/LAppLive2DManager.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppLive2DManager.java
@@ -9,6 +9,7 @@ package com.live2d.demo.full;
 
 import com.live2d.sdk.cubism.framework.math.CubismMatrix44;
 import com.live2d.sdk.cubism.framework.motion.ACubismMotion;
+import com.live2d.sdk.cubism.framework.motion.IBeganMotionCallback;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
 
 import java.io.IOException;
@@ -154,7 +155,7 @@ public class LAppLive2DManager {
                     LAppPal.printLog("hit area: " + HitAreaName.HEAD.getId());
                 }
 
-                model.startRandomMotion(MotionGroup.TAP_BODY.getId(), Priority.NORMAL.getPriority(), finishedMotion);
+                model.startRandomMotion(MotionGroup.TAP_BODY.getId(), Priority.NORMAL.getPriority(), finishedMotion, beganMotion);
             }
         }
     }
@@ -218,7 +219,7 @@ public class LAppLive2DManager {
         LAppDelegate.getInstance().getView().switchRenderingTarget(useRenderingTarget);
 
         // 別レンダリング先を選択した際の背景クリア色
-        float[] clearColor = {1.0f, 1.0f, 1.0f};
+        float[] clearColor = {0.0f, 0.0f, 0.0f};
         LAppDelegate.getInstance().getView().setRenderingTargetClearColor(clearColor[0], clearColor[1], clearColor[2]);
     }
 
@@ -255,6 +256,18 @@ public class LAppLive2DManager {
         }
         return models.size();
     }
+
+    /**
+     * モーション再生時に実行されるコールバック関数
+     */
+    private static class BeganMotion implements IBeganMotionCallback {
+        @Override
+        public void execute(ACubismMotion motion) {
+            LAppPal.printLog("Motion Began: " + motion);
+        }
+    }
+
+    private static final BeganMotion beganMotion = new BeganMotion();
 
     /**
      * モーション終了時に実行されるコールバック関数

--- a/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
@@ -22,6 +22,7 @@ import com.live2d.sdk.cubism.framework.model.CubismUserModel;
 import com.live2d.sdk.cubism.framework.motion.ACubismMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
+import com.live2d.sdk.cubism.framework.motion.IBeganMotionCallback;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
 import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismOffscreenSurfaceAndroid;
@@ -186,7 +187,7 @@ public class LAppModel extends CubismUserModel {
      * @return 開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判別するisFinished()の引数で使用する。開始できない時は「-1」
      */
     public int startMotion(final String group, int number, int priority) {
-        return startMotion(group, number, priority, null);
+        return startMotion(group, number, priority, null, null);
     }
 
     /**
@@ -201,7 +202,8 @@ public class LAppModel extends CubismUserModel {
     public int startMotion(final String group,
                            int number,
                            int priority,
-                           IFinishedMotionCallback onFinishedMotionHandler
+                           IFinishedMotionCallback onFinishedMotionHandler,
+                           IBeganMotionCallback onBeganMotionHandler
     ) {
         if (priority == LAppDefine.Priority.FORCE.getPriority()) {
             motionManager.setReservationPriority(priority);
@@ -225,7 +227,7 @@ public class LAppModel extends CubismUserModel {
                 byte[] buffer;
                 buffer = createBuffer(path);
 
-                motion = loadMotion(buffer, onFinishedMotionHandler);
+                motion = loadMotion(buffer, onFinishedMotionHandler, onBeganMotionHandler);
                 if (motion != null) {
                     final float fadeInTime = modelSetting.getMotionFadeInTimeValue(group, number);
 
@@ -242,6 +244,7 @@ public class LAppModel extends CubismUserModel {
                 }
             }
         } else {
+            motion.setBeganMotionHandler(onBeganMotionHandler);
             motion.setFinishedMotionHandler(onFinishedMotionHandler);
         }
 
@@ -270,7 +273,7 @@ public class LAppModel extends CubismUserModel {
      * @return 開始したモーションの識別番号。個別のモーションが終了したか否かを判定するisFinished()の引数で使用する。開始できない時は「-1」
      */
     public int startRandomMotion(final String group, int priority) {
-        return startRandomMotion(group, priority, null);
+        return startRandomMotion(group, priority, null, null);
     }
 
     /**
@@ -281,7 +284,7 @@ public class LAppModel extends CubismUserModel {
      * @param onFinishedMotionHandler モーション再生終了時に呼び出されるコールバック関数。nullの場合は呼び出されない。
      * @return 開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判定するisFinished()の引数で使用する。開始できない時は-1
      */
-    public int startRandomMotion(final String group, int priority, IFinishedMotionCallback onFinishedMotionHandler) {
+    public int startRandomMotion(final String group, int priority, IFinishedMotionCallback onFinishedMotionHandler, IBeganMotionCallback onBeganMotionHandler) {
         if (modelSetting.getMotionCount(group) == 0) {
             return -1;
         }
@@ -289,7 +292,7 @@ public class LAppModel extends CubismUserModel {
         Random random = new Random();
         int number = random.nextInt(Integer.MAX_VALUE) % modelSetting.getMotionCount(group);
 
-        return startMotion(group, number, priority, onFinishedMotionHandler);
+        return startMotion(group, number, priority, onFinishedMotionHandler, onBeganMotionHandler);
     }
 
     public void draw(CubismMatrix44 matrix) {

--- a/Sample/src/minimum/AndroidManifest.xml
+++ b/Sample/src/minimum/AndroidManifest.xml
@@ -15,7 +15,7 @@
     <activity
       android:name=".minimum.MainActivityMinimum"
       android:configChanges="orientation|screenSize"
-      android:screenOrientation="landscape"
+      android:screenOrientation="sensorLandscape"
       android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumDelegate.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumDelegate.java
@@ -96,7 +96,6 @@ public class LAppMinimumDelegate {
         // アプリケーションを非アクティブにする
         if (!isActive) {
             activity.finishAndRemoveTask();
-            System.exit(0);
         }
     }
 

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumLive2DManager.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumLive2DManager.java
@@ -51,8 +51,14 @@ public class LAppMinimumLive2DManager {
             viewMatrix.multiplyByMatrix(projection);
         }
 
+        // 描画前コール
+        LAppMinimumDelegate.getInstance().getView().preModelDraw(model);
+
         model.update();
         model.draw(projection);     // 参照渡しなのでprojectionは変質する
+
+        // 描画後コール
+        LAppMinimumDelegate.getInstance().getView().postModelDraw(model);
     }
 
     /**

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumModel.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumModel.java
@@ -20,6 +20,7 @@ import com.live2d.sdk.cubism.framework.model.CubismUserModel;
 import com.live2d.sdk.cubism.framework.motion.ACubismMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
+import com.live2d.sdk.cubism.framework.motion.IBeganMotionCallback;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
 import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismOffscreenSurfaceAndroid;
@@ -146,7 +147,6 @@ public class LAppMinimumModel extends CubismUserModel {
 
     /**
      * 引数で指定したモーションの再生を開始する。
-     * コールバック関数が渡されなかった場合にそれをnullとして同メソッドを呼び出す。
      *
      * @param group    モーショングループ名
      * @param number   グループ内の番号
@@ -154,22 +154,6 @@ public class LAppMinimumModel extends CubismUserModel {
      * @return 開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判別するisFinished()の引数で使用する。開始できない時は「-1」
      */
     public int startMotion(final String group, int number, int priority) {
-        return startMotion(group, number, priority, null);
-    }
-
-    /**
-     * 引数で指定したモーションの再生を開始する。
-     *
-     * @param group                   モーショングループ名
-     * @param number                  グループ内の番号
-     * @param priority                優先度
-     * @param onFinishedMotionHandler モーション再生終了時に呼び出されるコールバック関数。nullの場合は呼び出されない。
-     * @return 開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判定するisFinished()の引数で使用する。開始できない時は「-1」
-     */
-    public int startMotion(final String group,
-                           int number,
-                           int priority,
-                           IFinishedMotionCallback onFinishedMotionHandler) {
         if (priority == LAppDefine.Priority.FORCE.getPriority()) {
             motionManager.setReservationPriority(priority);
         } else if (!motionManager.reserveMotion(priority)) {
@@ -193,7 +177,7 @@ public class LAppMinimumModel extends CubismUserModel {
                 byte[] buffer;
                 buffer = LAppMinimumPal.loadFileAsBytes(path);
 
-                CubismMotion tmpMotion = loadMotion(buffer, onFinishedMotionHandler);
+                CubismMotion tmpMotion = loadMotion(buffer);
                 if (tmpMotion != null) {
                     motion = (CubismMotion) tmpMotion;
 
@@ -208,8 +192,6 @@ public class LAppMinimumModel extends CubismUserModel {
                     }
                 }
             }
-        } else {
-            motion.setFinishedMotionHandler(onFinishedMotionHandler);
         }
 
         if (LAppDefine.DEBUG_LOG_ENABLE) {
@@ -443,7 +425,6 @@ public class LAppMinimumModel extends CubismUserModel {
         }
     }
 
-
     private ICubismModelSetting modelSetting;
     /**
      * モデルのホームディレクトリ
@@ -492,5 +473,5 @@ public class LAppMinimumModel extends CubismUserModel {
     /**
      * フレームバッファ以外の描画先
      */
-    private CubismOffscreenSurfaceAndroid renderingBuffer;
+    private CubismOffscreenSurfaceAndroid renderingBuffer = new CubismOffscreenSurfaceAndroid();
 }

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumSprite.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumSprite.java
@@ -9,6 +9,8 @@ package com.live2d.demo.minimum;
 
 import android.opengl.GLES20;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
 import static android.opengl.GLES20.GL_FLOAT;
@@ -34,7 +36,7 @@ public class LAppMinimumSprite {
         positionLocation = GLES20.glGetAttribLocation(programId, "position");
         uvLocation = GLES20.glGetAttribLocation(programId, "uv");
         textureLocation = GLES20.glGetUniformLocation(programId, "texture");
-        colorLocation = GLES20.glGetAttribLocation(programId, "baseColor");
+        colorLocation = GLES20.glGetUniformLocation(programId, "baseColor");
 
         spriteColor[0] = 1.0f;
         spriteColor[1] = 1.0f;
@@ -65,8 +67,24 @@ public class LAppMinimumSprite {
         };
 
         // attribute属性を登録
-        GLES20.glVertexAttribPointer(positionLocation, 2, GL_FLOAT, false, 0, FloatBuffer.wrap(positionVertex));
-        GLES20.glVertexAttribPointer(uvLocation, 2, GL_FLOAT, false, 0, FloatBuffer.wrap(uvVertex));
+        {
+            ByteBuffer bb = ByteBuffer.allocateDirect(positionVertex.length * 4);
+            bb.order(ByteOrder.nativeOrder());
+            FloatBuffer buffer = bb.asFloatBuffer();
+            buffer.put(positionVertex);
+            buffer.position(0);
+
+            GLES20.glVertexAttribPointer(positionLocation, 2, GL_FLOAT, false, 0, buffer);
+        }
+        {
+            ByteBuffer bb = ByteBuffer.allocateDirect(uvVertex.length * 4);
+            bb.order(ByteOrder.nativeOrder());
+            FloatBuffer buffer = bb.asFloatBuffer();
+            buffer.put(uvVertex);
+            buffer.position(0);
+
+            GLES20.glVertexAttribPointer(uvLocation, 2, GL_FLOAT, false, 0, buffer);
+        }
 
         GLES20.glUniform4f(colorLocation, spriteColor[0], spriteColor[1], spriteColor[2], spriteColor[3]);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,8 +25,8 @@ PROP_MIN_SDK_VERSION=21
 # Android SDK version that will be used as the latest version of android this application has been tested on
 PROP_TARGET_SDK_VERSION=34
 # List of CPU Archtexture to build that application with
-# Available architextures (armeabi-v7a | arm64-v8a | x86)
+# Available architextures (arm64-v8a | x86)
 # To build for multiple architexture, use the `:` between them
-# Example - PROP_APP_ABI=armeabi-v7a:arm64-v8a:x86
+# Example - PROP_APP_ABI=arm64-v8a:x86
 #PROP_APP_ABI=armeabi-v7a:arm64-v8a
-PROP_APP_ABI=armeabi-v7a:arm64-v8a:x86:x86_64
+PROP_APP_ABI=arm64-v8a:x86:x86_64


### PR DESCRIPTION
### Added

* Add a function to notify when motion playback starts.
* Add right orientation to the fixed orientations in the Android app.
* Add a feature to change render target to the minimum sample.

### Fixed

* Fix a hang-up caused by an improper function call in the application termination process.
* Fix a bug that caused white edge-like objects to be drawn when enabling the `USE_RENDER_TARGET` or `USE_MODEL_RENDER_TARGET` flag in `LAppDefine`.
* Fix a bug where the method of obtaining color location differs between full sample and minimum sample.

### Removed

* Remove armeabi-v7a from architecture support.
* Remove the `startMotion()` method that receives a callback in the minimum sample.
  * If you want to use the callback feature, please check the Full sample.