### PR TITLE
Update to Cubism 5 SDK for Java R3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.3] - 2025-02-18
+
+### Fixed
+
+* Fix a bug where the application crashes when tapping the model repeatedly.
+
+### Changed
+
+* Change the compile and target SDK version of Android OS to 15.0 (API 35).
+  * Upgrade the version of Android Gradle Plugin from 8.1.1 to 8.6.1.
+  * Upgrade the version of Gradle from 8.2 to 8.7.
+  * Change the minimum version of Android Studio to Ladybug(2024.2.1).
+
+
 ## [5-r.2] - 2024-11-07
 
 ### Added
@@ -162,6 +176,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * New released!
 
 
+[5-r.3]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.2...5-r.3
 [5-r.2]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.3...5-r.1
 [5-r.1-beta.3]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.2...5-r.1-beta.3

--- a/README.ja.md
+++ b/README.ja.md
@@ -72,9 +72,10 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 | 開発ツール          | バージョン            |
 |----------------|------------------|
 | Android Studio | Ladybug 2024.2.1 Patch 2 |
-| Gradle         | 8.2           |
+| Gradle         | 8.7           |
+| Android Gradle Plugin | 8.6.1 |
 | Gradle JDK | 17.0.12 |
-| Android SDK | 34.0.0       |
+| Android SDK | 35.0.0       |
 
 ## 動作確認環境
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 | Development Tools | Version |
 |-------------------|--|
 | Android Studio    | Ladybug 2024.2.1 Patch 2 |
-| Gradle            | 8.2 |
+| Gradle            | 8.7 |
+| Android Gradle Plugin | 8.6.1 |
 | Gradle JDK | 17.0.12 |
-| Android SDK | 34.0.0       |
+| Android SDK | 35.0.0       |
 
 ## Operation environment
 

--- a/Sample/src/full/java/com/live2d/demo/full/MainActivity.java
+++ b/Sample/src/full/java/com/live2d/demo/full/MainActivity.java
@@ -96,21 +96,29 @@ public class MainActivity extends Activity {
     }
 
     @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        float pointX = event.getX();
-        float pointY = event.getY();
+    public boolean onTouchEvent(final MotionEvent event) {
+        final float pointX = event.getX();
+        final float pointY = event.getY();
 
-        switch (event.getAction()) {
-            case MotionEvent.ACTION_DOWN:
-                LAppDelegate.getInstance().onTouchBegan(pointX, pointY);
-                break;
-            case MotionEvent.ACTION_UP:
-                LAppDelegate.getInstance().onTouchEnd(pointX, pointY);
-                break;
-            case MotionEvent.ACTION_MOVE:
-                LAppDelegate.getInstance().onTouchMoved(pointX, pointY);
-                break;
-        }
+        // GLSurfaceViewのイベント処理キューにタッチイベントを追加する。
+        glSurfaceView.queueEvent(
+            new Runnable() {
+                @Override
+                public void run() {
+                    switch (event.getAction()) {
+                        case MotionEvent.ACTION_DOWN:
+                            LAppDelegate.getInstance().onTouchBegan(pointX, pointY);
+                            break;
+                        case MotionEvent.ACTION_UP:
+                            LAppDelegate.getInstance().onTouchEnd(pointX, pointY);
+                            break;
+                        case MotionEvent.ACTION_MOVE:
+                            LAppDelegate.getInstance().onTouchMoved(pointX, pointY);
+                            break;
+                    }
+                }
+            }
+        );
         return super.onTouchEvent(event);
     }
 

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/MainActivityMinimum.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/MainActivityMinimum.java
@@ -64,21 +64,29 @@ public class MainActivityMinimum extends Activity {
     }
 
     @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        float pointX = event.getX();
-        float pointY = event.getY();
+    public boolean onTouchEvent(final MotionEvent event) {
+        final float pointX = event.getX();
+        final float pointY = event.getY();
 
-        switch (event.getAction()) {
-            case MotionEvent.ACTION_DOWN:
-                LAppMinimumDelegate.getInstance().onTouchBegan(pointX, pointY);
-                break;
-            case MotionEvent.ACTION_UP:
-                LAppMinimumDelegate.getInstance().onTouchEnd(pointX, pointY);
-                break;
-            case MotionEvent.ACTION_MOVE:
-                LAppMinimumDelegate.getInstance().onTouchMoved(pointX, pointY);
-                break;
-        }
+        // GLSurfaceViewのイベント処理キューにタッチイベントを追加する。
+        _glSurfaceView.queueEvent(
+            new Runnable() {
+                @Override
+                public void run() {
+                    switch (event.getAction()) {
+                        case MotionEvent.ACTION_DOWN:
+                            LAppMinimumDelegate.getInstance().onTouchBegan(pointX, pointY);
+                            break;
+                        case MotionEvent.ACTION_UP:
+                            LAppMinimumDelegate.getInstance().onTouchEnd(pointX, pointY);
+                            break;
+                        case MotionEvent.ACTION_MOVE:
+                            LAppMinimumDelegate.getInstance().onTouchMoved(pointX, pointY);
+                            break;
+                    }
+                }
+            }
+        );
         return super.onTouchEvent(event);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.6.1'
 //        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,11 +19,11 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Added later
 # Android SDK version that will be used as the compiled project
-PROP_COMPILE_SDK_VERSION=34
+PROP_COMPILE_SDK_VERSION=35
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=34
+PROP_TARGET_SDK_VERSION=35
 # List of CPU Archtexture to build that application with
 # Available architextures (arm64-v8a | x86)
 # To build for multiple architexture, use the `:` between them

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 11 17:28:23 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Fixed

* Fix a bug where the application crashes when tapping the model repeatedly.

### Changed

* Change the compile and target SDK version of Android OS to 15.0 (API 35).
  * Upgrade the version of Android Gradle Plugin from 8.1.1 to 8.6.1.
  * Upgrade the version of Gradle from 8.2 to 8.7.
  * Change the minimum version of Android Studio to Ladybug(2024.2.1).