### PR TITLE
Update to Cubism 5 SDK for Java R4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.4] - 2025-05-15
+
+### Added
+
+* Add a flag to enable the function that verifies the consistency when loading `motion3.json`.
+
+### Changed
+
+* Change the blend mode when using the `USE_RENDER_TARGET` or `USE_MODEL_RENDER_TARGET` flags in `LAppDefine`, and apply Premultiplied Alpha to the color settings of rendering targets.
+Also adjust the return value of the getSpriteAlpha function.
+
+
 ## [5-r.3] - 2025-02-18
 
 ### Fixed
 
 * Fix a bug where the application crashes when tapping the model repeatedly.
+* Fix a bug where the priority was not reset if the motion was not read correctly.
 
 ### Changed
 
@@ -17,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * Upgrade the version of Android Gradle Plugin from 8.1.1 to 8.6.1.
   * Upgrade the version of Gradle from 8.2 to 8.7.
   * Change the minimum version of Android Studio to Ladybug(2024.2.1).
+* Change the default JDK version for compilation to 17 using Gradle's Java toolchain.
 
 
 ## [5-r.2] - 2024-11-07
@@ -176,6 +190,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * New released!
 
 
+[5-r.4]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.3...5-r.4
 [5-r.3]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.2...5-r.3
 [5-r.2]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1-beta.3...5-r.1

--- a/Core/CHANGELOG.md
+++ b/Core/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2025-04-24
+
+### Added
+
+* Add the function `csmGetParameterRepeats`.
+  * This function retrieves whether the parameters are set to repeat.
+
+### Changed
+
+* Upgrade Core version to 05.01.0000.
+
+### Fixed
+
+* Fix `csmGetParameterKeyCounts()` and `csmGetParameterKeyValues()` symbols in the DLL.
+
+
+## 2024-12-19
+
+### Removed
+
+* [Native] Remove Visual Studio 2013 (MSVC 120) static library.
+
+
 ## 2024-11-07
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,11 +71,11 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | 開発ツール          | バージョン            |
 |----------------|------------------|
-| Android Studio | Ladybug 2024.2.1 Patch 2 |
-| Gradle         | 8.7           |
+| Android Studio | Meerkat Feature Drop 2024.3.2 |
+| Gradle | 8.7 |
 | Android Gradle Plugin | 8.6.1 |
-| Gradle JDK | 17.0.12 |
-| Android SDK | 35.0.0       |
+| Gradle JDK | 21.0.7 |
+| Android SDK | 35.0.0 |
 
 ## 動作確認環境
 
@@ -87,7 +87,7 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | バージョン | デバイス     | エミュレーター |
 |-------|----------|:-------:|
-| 14    | Pixel 7a |         |
+| 15    | Pixel 7a |         |
 | 5.0   | Pixel 7a |    ✔    |
 
 本サンプルアプリケーションは**Android API 21**以上のAndroidバージョンで動作します。

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | Development Tools | Version |
 |-------------------|--|
-| Android Studio    | Ladybug 2024.2.1 Patch 2 |
-| Gradle            | 8.7 |
+| Android Studio | Meerkat Feature Drop 2024.3.2 |
+| Gradle | 8.7 |
 | Android Gradle Plugin | 8.6.1 |
-| Gradle JDK | 17.0.12 |
-| Android SDK | 35.0.0       |
+| Gradle JDK | 21.0.7 |
+| Android SDK | 35.0.0 |
 
 ## Operation environment
 
@@ -87,7 +87,7 @@ This sample application runs with **Java SE 7** or higher Java versions.
 
 | Version | Device   | Emulator |
 |---------|----------|:--------:|
-| 14      | Pixel 7a |          |
+| 15      | Pixel 7a |          |
 | 5.0     | Pixel 7a |    ✔     |
 
 This sample application runs with **Android API 21** or higher Android versions.

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -61,6 +61,12 @@ android {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'

--- a/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
@@ -73,7 +73,7 @@ public class LAppDelegate {
 
         // 透過設定
         GLES20.glEnable(GLES20.GL_BLEND);
-        GLES20.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        GLES20.glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
         // Initialize Cubism SDK framework
         CubismFramework.initialize();

--- a/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
@@ -41,6 +41,10 @@ public class LAppModel extends CubismUserModel {
             mocConsistency = true;
         }
 
+        if (LAppDefine.MOTION_CONSISTENCY_VALIDATION_ENABLE) {
+            motionConsistency = true;
+        }
+
         if (LAppDefine.DEBUG_LOG_ENABLE) {
             debugMode = true;
         }
@@ -227,7 +231,7 @@ public class LAppModel extends CubismUserModel {
                 byte[] buffer;
                 buffer = createBuffer(path);
 
-                motion = loadMotion(buffer, onFinishedMotionHandler, onBeganMotionHandler);
+                motion = loadMotion(buffer, onFinishedMotionHandler, onBeganMotionHandler, motionConsistency);
                 if (motion != null) {
                     final float fadeInTime = modelSetting.getMotionFadeInTimeValue(group, number);
 
@@ -241,6 +245,12 @@ public class LAppModel extends CubismUserModel {
                     }
 
                     motion.setEffectIds(eyeBlinkIds, lipSyncIds);
+                } else {
+                    CubismDebug.cubismLogError("Can't start motion %s", path);
+
+                    // ロードできなかったモーションのReservePriorityをリセットする。
+                    motionManager.setReservationPriority(LAppDefine.Priority.NONE.getPriority());
+                    return -1;
                 }
             }
         } else {
@@ -570,7 +580,7 @@ public class LAppModel extends CubismUserModel {
                 buffer = createBuffer(modelPath);
 
                 // If a motion cannot be loaded, a process is skipped.
-                CubismMotion tmp = loadMotion(buffer);
+                CubismMotion tmp = loadMotion(buffer, motionConsistency);
                 if (tmp == null) {
                     continue;
                 }

--- a/Sample/src/full/java/com/live2d/demo/full/LAppSprite.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppSprite.java
@@ -54,6 +54,8 @@ public class LAppSprite {
         uvVertex[6] = 1.0f;
         uvVertex[7] = 1.0f;
 
+        // 透過設定
+        GLES20.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
         GLES20.glEnableVertexAttribArray(positionLocation);
         GLES20.glEnableVertexAttribArray(uvLocation);

--- a/Sample/src/full/java/com/live2d/demo/full/LAppView.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppView.java
@@ -7,12 +7,16 @@
 
 package com.live2d.demo.full;
 
+import android.opengl.GLES20;
+
 import com.live2d.demo.TouchManager;
 import com.live2d.sdk.cubism.framework.math.CubismMatrix44;
 import com.live2d.sdk.cubism.framework.math.CubismViewMatrix;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismOffscreenSurfaceAndroid;
 
 import static com.live2d.demo.LAppDefine.*;
+
+import static android.opengl.GLES20.*;
 
 public class LAppView implements AutoCloseable {
     /**
@@ -177,11 +181,12 @@ public class LAppView implements AutoCloseable {
                 1.0f, 0.0f
             };
 
+
             for (int i = 0; i < live2dManager.getModelNum(); i++) {
                 LAppModel model = live2dManager.getModel(i);
                 float alpha = i < 1 ? 1.0f : model.getOpacity();    // 片方のみ不透明度を取得できるようにする。
 
-                renderingSprite.setColor(1.0f, 1.0f, 1.0f, alpha);
+                renderingSprite.setColor(1.0f * alpha, 1.0f * alpha, 1.0f * alpha, alpha);
 
                 if (model != null) {
                     renderingSprite.setWindowSize(maxWidth, maxHeight);
@@ -199,6 +204,9 @@ public class LAppView implements AutoCloseable {
     public void preModelDraw(LAppModel refModel) {
         // 別のレンダリングターゲットへ向けて描画する場合の使用するオフスクリーンサーフェス
         CubismOffscreenSurfaceAndroid useTarget;
+
+        // 透過設定
+        GLES20.glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
         // 別のレンダリングターゲットへ向けて描画する場合
         if (renderingTarget != RenderingTarget.NONE) {
@@ -248,7 +256,7 @@ public class LAppView implements AutoCloseable {
                     0.0f, 0.0f,
                     1.0f, 0.0f
                 };
-                renderingSprite.setColor(1.0f, 1.0f, 1.0f, getSpriteAlpha(0));
+                renderingSprite.setColor(1.0f * getSpriteAlpha(0), 1.0f * getSpriteAlpha(0), 1.0f * getSpriteAlpha(0), getSpriteAlpha(0));
 
                 // 画面サイズを取得する。
                 int maxWidth = LAppDelegate.getInstance().getWindowWidth();
@@ -397,7 +405,7 @@ public class LAppView implements AutoCloseable {
      */
     public float getSpriteAlpha(int assign) {
         // assignの数値に応じて適当な差をつける
-        float alpha = 0.25f + (float) assign * 0.5f;
+        float alpha = 0.4f + (float) assign * 0.5f;
 
         // サンプルとしてαに適当な差をつける
         if (alpha > 1.0f) {

--- a/Sample/src/main/java/com/live2d/demo/LAppDefine.java
+++ b/Sample/src/main/java/com/live2d/demo/LAppDefine.java
@@ -218,6 +218,11 @@ public class LAppDefine {
     public static final boolean MOC_CONSISTENCY_VALIDATION_ENABLE = true;
 
     /**
+     * motion3.jsonの整合性を検証するかどうか。有効ならtrue。
+     */
+    public static final boolean MOTION_CONSISTENCY_VALIDATION_ENABLE = true;
+
+    /**
      * Enable/Disable debug logging.
      */
     public static final boolean DEBUG_LOG_ENABLE = true;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+}
+
 rootProject.name = "Demo"
 include ':Framework:framework'
 include ':Sample'


### PR DESCRIPTION
### Added

* Add a flag to enable the function that verifies the consistency when loading `motion3.json`.

### Changed

* Change the blend mode when using the `USE_RENDER_TARGET` or `USE_MODEL_RENDER_TARGET` flags in `LAppDefine`, and apply Premultiplied Alpha to the color settings of rendering targets.
Also adjust the return value of the getSpriteAlpha function.