### PR TITLE
Update to Cubism 5 SDK for Java R4_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.4.1] - 2025-07-17
+
+### Changed
+
+* Implement support for Android 16KB page size.
+  * See `CHANGELOG.md` in Core.
+* Change audio attribute to be played from `USAGE_VOICE_COMMUNICATION` to `USAGE_GAME`.
+
+
 ## [5-r.4] - 2025-05-15
 
 ### Added
@@ -190,6 +199,7 @@ Also adjust the return value of the getSpriteAlpha function.
 * New released!
 
 
+[5-r.4.1]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.4...5-r.4.1
 [5-r.4]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.3...5-r.4
 [5-r.3]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.2...5-r.3
 [5-r.2]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.1...5-r.2

--- a/Core/CHANGELOG.md
+++ b/Core/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2025-07-17
+
+### Changed
+
+* [Unity,Native,Java] Implement support for Android 16KB page size.
+
+
 ## 2025-04-24
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,7 +71,7 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | 開発ツール          | バージョン            |
 |----------------|------------------|
-| Android Studio | Meerkat Feature Drop 2024.3.2 |
+| Android Studio | Narwhal 2025.1.1 Patch 1 |
 | Gradle | 8.7 |
 | Android Gradle Plugin | 8.6.1 |
 | Gradle JDK | 21.0.7 |
@@ -85,12 +85,14 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 ### Android
 
-| バージョン | デバイス     | エミュレーター |
-|-------|----------|:-------:|
-| 15    | Pixel 7a |         |
-| 5.0   | Pixel 7a |    ✔    |
+| バージョン | デバイス     | エミュレーター | 16KBページサイズ *1 |
+|-------|----------|:-------:|:-------:|
+| 16    | Pixel 9  |         |    ✔︎    |
+| 15    | Pixel 7a |         |  |
+| 5.0   | Pixel 7a |    ✔    |  |
 
 本サンプルアプリケーションは**Android API 21**以上のAndroidバージョンで動作します。
+*1 開発者向けオプションを使用して有効にした環境となります
 
 ## プロジェクトへの貢献
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | Development Tools | Version |
 |-------------------|--|
-| Android Studio | Meerkat Feature Drop 2024.3.2 |
+| Android Studio | Narwhal 2025.1.1 Patch 1 |
 | Gradle | 8.7 |
 | Android Gradle Plugin | 8.6.1 |
 | Gradle JDK | 21.0.7 |
@@ -85,12 +85,14 @@ This sample application runs with **Java SE 7** or higher Java versions.
 
 ### Android
 
-| Version | Device   | Emulator |
-|---------|----------|:--------:|
-| 15      | Pixel 7a |          |
-| 5.0     | Pixel 7a |    ✔     |
+| Version | Device   | Emulator | 16KB page sizes *1 |
+|---------|----------|:--------:|:--------:|
+| 16      | Pixel 9  |          |     ✔︎    |
+| 15      | Pixel 7a |          |          |
+| 5.0     | Pixel 7a |    ✔     |          |
 
 This sample application runs with **Android API 21** or higher Android versions.
+*1 This environment has been enabled using developer options.
 
 ## Contributing
 

--- a/Sample/src/full/java/com/live2d/demo/full/LAppWavFileHandler.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppWavFileHandler.java
@@ -57,7 +57,7 @@ public class LAppWavFileHandler extends Thread {
         AudioTrack audioTrack;
         audioTrack = new AudioTrack.Builder()
             .setAudioAttributes(new AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                .setUsage(AudioAttributes.USAGE_GAME)
                 .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                 .build())
             .setAudioFormat(new AudioFormat.Builder()


### PR DESCRIPTION
### Changed

* Implement support for Android 16KB page size.
  * See `CHANGELOG.md` in Core.
* Change audio attribute to be played from `USAGE_VOICE_COMMUNICATION` to `USAGE_GAME`.