### PR TITLE
Update to Cubism 5 SDK for Java R5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.5] - 2026-06-04
+
+### Changed
+
+* Migrate system bar hiding in `MainActivity` and `MainActivityMinimum` classes from deprecated `setSystemUiVisibility()` to `WindowInsetsControllerCompat`.
+* Reorganize lifecycle methods in the `LAppDelegate` and `LAppMinimumDelegate` classes to reliably reconstruct rendering resources on GL surface recreation.
+* Change motion calculation order in `LAppModel` and `LAppMinimumModel` classes to be performed by `CubismUpdateScheduler` class with per-feature Updaters.
+* Change `LAppModel` and `LAppMinimumModel` classes to configure parameter IDs and settings for target tracking via `CubismLook` class.
+* Change `LAppWavFileHandler` class to implement the `IParameterProvider` interface.
+
+### Fixed
+
+* Fix collision detection misalignment in split-screen mode.
+* Fix app state reset when entering split-screen mode.
+* Fix the model being clipped by system bars in the Minimum sample app on Android 15 or later.
+* Fix an issue in the Android sample where shaders were rebuilt every time the app returned to the foreground.
+* Unify remaining uses of `OffscreenSurface` in comments to `RenderTarget`.
+* Fix missing resource release in `close()` method of the `LAppView` and `LAppMinimumView` classes.
+* Fix incorrect debug log output when tapping the body hit area of the model.
+* Fix the bug where Y-axis coordinate transform methods incorrectly used X-axis methods in the `LAppView` and `LAppMinimumView` classes.
+* Fix an issue where `PREMULTIPLIED_ALPHA_ENABLE` flag was not applied to texture loading in the `LAppTextureManager` and `LAppMinimumTextureManager` classes.
+* Fix an issue where `PREMULTIPLIED_ALPHA_ENABLE` flag was not referenced for renderer premultiplied alpha setting in the `LAppMinimumModel` class.
+
+
 ## [5-r.5-beta.1.1] - 2026-02-19
 
 ### Fixed
 
-* Fix some problems related to rendering and clipping mask. 
+* Fix some problems related to rendering and clipping mask.
   * See `CHANGELOG.md` in Framework.
 
 
@@ -230,6 +254,7 @@ Also adjust the return value of the getSpriteAlpha function.
 * New released!
 
 
+[5-r.5]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.5-beta.1.1...5-r.5
 [5-r.5-beta.1.1]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.5-beta.1...5-r.5-beta.1.1
 [5-r.5-beta.1]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.4.1...5-r.5-beta.1
 [5-r.4.1]: https://github.com/Live2D/CubismJavaSamples/compare/5-r.4...5-r.4.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,11 +71,11 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | 開発ツール          | バージョン            |
 |----------------|------------------|
-| Android Studio | Panda 1 2025.3.1 Patch 1 |
+| Android Studio | Panda 4 2025.3.4 Patch 1 |
 | Gradle | 8.11.1 |
 | Android Gradle Plugin | 8.9.1 |
 | Gradle JDK | 21.0.7 |
-| Android SDK | 36.0.0 |
+| Android SDK Platform | 36.0 |
 
 ## 動作確認環境
 
@@ -85,11 +85,12 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 ### Android
 
-| バージョン | デバイス     | エミュレーター | 16KBページサイズ *1 |
-|-------|----------|:-------:|:-------:|
-| 16    | Pixel 9  |         |    ✔︎    |
-| 16    | Pixel 7a |         |  |
-| 5.0   | Pixel 7a |    ✔    |  |
+| API レベル | デバイス     | 16KBページサイズ *1 |
+|---------|----------|:-------------:|
+| 36      | Pixel 9  |      ✔︎       |
+| 36      | Pixel 7a |               |
+
+※ エミュレーターは API 21 / 36 で動作確認済み
 
 本サンプルアプリケーションは**Android API 21**以上のAndroidバージョンで動作します。
 *1 開発者向けオプションを使用して有効にした環境となります

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Core : [CHANGELOG.md](Core/CHANGELOG.md)
 
 | Development Tools | Version |
 |-------------------|--|
-| Android Studio | Panda 1 2025.3.1 Patch 1 |
+| Android Studio | Panda 4 2025.3.4 Patch 1 |
 | Gradle | 8.11.1 |
 | Android Gradle Plugin | 8.9.1 |
 | Gradle JDK | 21.0.7 |
-| Android SDK | 36.0.0 |
+| Android SDK Platform | 36.0 |
 
 ## Operation environment
 
@@ -85,11 +85,12 @@ This sample application runs with **Java SE 7** or higher Java versions.
 
 ### Android
 
-| Version | Device   | Emulator | 16KB page sizes *1 |
-|---------|----------|:--------:|:--------:|
-| 16      | Pixel 9  |          |     ✔︎    |
-| 16      | Pixel 7a |          |          |
-| 5.0     | Pixel 7a |    ✔     |          |
+| API Level | Device   | 16KB page sizes *1 |
+|-----------|----------|:------------------:|
+| 36        | Pixel 9  |         ✔︎         |
+| 36        | Pixel 7a |                    |
+
+Note: The emulator has been tested with API 21 / 36.
 
 This sample application runs with **Android API 21** or higher Android versions.
 *1 This environment has been enabled using developer options.

--- a/Sample/src/full/AndroidManifest.xml
+++ b/Sample/src/full/AndroidManifest.xml
@@ -14,7 +14,7 @@
     android:theme="@android:style/Theme.NoTitleBar">
     <activity
       android:name=".full.MainActivity"
-      android:configChanges="orientation|screenSize"
+      android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
       android:screenOrientation="fullUser"
       android:exported="true">
       <intent-filter>

--- a/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppDelegate.java
@@ -12,6 +12,7 @@ import android.opengl.GLES20;
 import android.os.Build;
 import com.live2d.demo.LAppDefine;
 import com.live2d.sdk.cubism.framework.CubismFramework;
+import com.live2d.sdk.cubism.framework.rendering.android.CubismShaderAndroid;
 
 import static android.opengl.GLES20.*;
 
@@ -40,17 +41,15 @@ public class LAppDelegate {
     }
 
     public void onStart(Activity activity) {
-        textureManager = new LAppTextureManager();
-        view = new LAppView();
-
         this.activity = activity;
-
-        LAppPal.updateTime();
+        isActive = true;
     }
 
     public void onPause() {}
 
-    public void onStop() {
+    public void onStop() {}
+
+    public void onDestroy() {
         if (view != null) {
             view.close();
         }
@@ -58,9 +57,7 @@ public class LAppDelegate {
 
         LAppLive2DManager.releaseInstance();
         CubismFramework.dispose();
-    }
 
-    public void onDestroy() {
         releaseInstance();
     }
 
@@ -73,8 +70,33 @@ public class LAppDelegate {
         GLES20.glEnable(GLES20.GL_BLEND);
         GLES20.glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
-        // Initialize Cubism SDK framework
-        CubismFramework.initialize();
+        if (textureManager == null) {
+            textureManager = new LAppTextureManager();
+        } else {
+            // 無効になっているテクスチャ情報を破棄
+            textureManager.releaseInvalidTextures();
+        }
+
+        if (view != null) {
+            view.close();
+        }
+        view = new LAppView();
+
+        LAppPal.updateTime();
+
+        if (!CubismFramework.isInitialized()) {
+            CubismFramework.initialize();
+        }
+
+        // 無効になっているOpenGLリソースを破棄
+        CubismShaderAndroid.getInstance().releaseInvalidShaderProgram();
+        // シェーダコードを再読み込みするためにインスタンスを破棄しておく
+        CubismShaderAndroid.deleteInstance();
+
+        LAppLive2DManager live2DManager = LAppLive2DManager.getInstance();
+        for (int i = 0; i < live2DManager.getModelNum(); i++) {
+            live2DManager.getModel(i).reloadRenderer();
+        }
     }
 
     public void onSurfaceChanged(int width, int height) {
@@ -89,14 +111,6 @@ public class LAppDelegate {
 
         // オフスクリーンのサイズ変更
         LAppLive2DManager.getInstance().setRenderTargetSize(width, height);
-
-        // load models
-        LAppLive2DManager manager = LAppLive2DManager.getInstance();
-        if (manager.getModelNum() == 0) {
-            manager.changeScene(sceneIndex);
-        }
-
-        isActive = true;
     }
 
     public void run() {

--- a/Sample/src/full/java/com/live2d/demo/full/LAppLive2DManager.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppLive2DManager.java
@@ -186,7 +186,7 @@ public class LAppLive2DManager {
             // 体をタップした場合ランダムモーションを開始する
             else if (model.hitTest(HitAreaName.BODY.getId(), adjustedX, adjustedY)) {
                 if (DEBUG_LOG_ENABLE) {
-                    LAppPal.printLog("hit area: " + HitAreaName.HEAD.getId());
+                    LAppPal.printLog("hit area: " + HitAreaName.BODY.getId());
                 }
 
                 model.startRandomMotion(MotionGroup.TAP_BODY.getId(), Priority.NORMAL.getPriority(), finishedMotion, beganMotion);

--- a/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppModel.java
@@ -14,16 +14,24 @@ import com.live2d.sdk.cubism.framework.CubismModelSettingJson;
 import com.live2d.sdk.cubism.framework.ICubismModelSetting;
 import com.live2d.sdk.cubism.framework.effect.CubismBreath;
 import com.live2d.sdk.cubism.framework.effect.CubismEyeBlink;
+import com.live2d.sdk.cubism.framework.effect.CubismLook;
 import com.live2d.sdk.cubism.framework.id.CubismId;
 import com.live2d.sdk.cubism.framework.id.CubismIdManager;
 import com.live2d.sdk.cubism.framework.math.CubismMatrix44;
 import com.live2d.sdk.cubism.framework.model.CubismMoc;
 import com.live2d.sdk.cubism.framework.model.CubismUserModel;
 import com.live2d.sdk.cubism.framework.motion.ACubismMotion;
+import com.live2d.sdk.cubism.framework.motion.CubismBreathUpdater;
 import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotion;
+import com.live2d.sdk.cubism.framework.motion.CubismExpressionUpdater;
+import com.live2d.sdk.cubism.framework.motion.CubismEyeBlinkUpdater;
+import com.live2d.sdk.cubism.framework.motion.CubismLookUpdater;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
+import com.live2d.sdk.cubism.framework.motion.CubismPhysicsUpdater;
+import com.live2d.sdk.cubism.framework.motion.CubismPoseUpdater;
 import com.live2d.sdk.cubism.framework.motion.IBeganMotionCallback;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
+import com.live2d.sdk.cubism.framework.motion.IBooleanSupplier;
 import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismRenderTargetAndroid;
 import com.live2d.sdk.cubism.framework.rendering.android.CubismRendererAndroid;
@@ -98,20 +106,31 @@ public class LAppModel extends CubismUserModel {
     }
 
     /**
+     * レンダラとテクスチャを再構築する。GLコンテキストが破棄された場合に呼び出す。
+     */
+    public void reloadRenderer() {
+        deleteRenderer();
+
+        CubismRenderer renderer = CubismRendererAndroid.create(
+            LAppDelegate.getInstance().getWindowWidth(),
+            LAppDelegate.getInstance().getWindowHeight()
+        );
+        setupRenderer(renderer);
+
+        setupTextures();
+    }
+
+    /**
      * モデルの更新処理。モデルのパラメーターから描画状態を決定する
      */
     public void update() {
         final float deltaTimeSeconds = LAppPal.getDeltaTime();
         userTimeSeconds += deltaTimeSeconds;
 
-        dragManager.update(deltaTimeSeconds);
-        dragX = dragManager.getX();
-        dragY = dragManager.getY();
-
         // モーションによるパラメーター更新の有無
-        boolean isMotionUpdated = false;
+        motionUpdated = false;
 
-//         前回セーブされた状態をロード
+        // 前回セーブされた状態をロード
         model.loadParameters();
 
         // モーションの再生がない場合、待機モーションの中からランダムで再生する
@@ -119,7 +138,7 @@ public class LAppModel extends CubismUserModel {
             startRandomMotion(LAppDefine.MotionGroup.IDLE.getId(), LAppDefine.Priority.IDLE.getPriority());
         } else {
             // モーションを更新
-            isMotionUpdated = motionManager.updateMotion(model, deltaTimeSeconds);
+            motionUpdated = motionManager.updateMotion(model, deltaTimeSeconds);
         }
 
         // モデルの状態を保存
@@ -128,58 +147,8 @@ public class LAppModel extends CubismUserModel {
         // 不透明度
         opacity = model.getModelOpacity();
 
-        // eye blink
-        // メインモーションの更新がないときだけまばたきする
-        if (!isMotionUpdated) {
-            if (eyeBlink != null) {
-                eyeBlink.updateParameters(model, deltaTimeSeconds);
-            }
-        }
-
-        // expression
-        if (expressionManager != null) {
-            // 表情でパラメータ更新（相対変化）
-            expressionManager.updateMotion(model, deltaTimeSeconds);
-        }
-
-        // ドラッグ追従機能
-        // ドラッグによる顔の向きの調整
-        model.addParameterValue(idParamAngleX, dragX * 30); // -30から30の値を加える
-        model.addParameterValue(idParamAngleY, dragY * 30);
-        model.addParameterValue(idParamAngleZ, dragX * dragY * (-30));
-
-        // ドラッグによる体の向きの調整
-        model.addParameterValue(idParamBodyAngleX, dragX * 10); // -10から10の値を加える
-
-        // ドラッグによる目の向きの調整
-        model.addParameterValue(idParamEyeBallX, dragX);  // -1から1の値を加える
-        model.addParameterValue(idParamEyeBallY, dragY);
-
-        // Breath Function
-        if (breath != null) {
-            breath.updateParameters(model, deltaTimeSeconds);
-        }
-
-        // Physics Setting
-        if (physics != null) {
-            physics.evaluate(model, deltaTimeSeconds);
-        }
-
-        // Lip Sync Setting
-        if (lipSync) {
-            // リアルタイムでリップシンクを行う場合、システムから音量を取得して0~1の範囲で値を入力します
-            float value = 0.0f;
-
-            for (int i = 0; i < lipSyncIds.size(); i++) {
-                CubismId lipSyncId = lipSyncIds.get(i);
-                model.addParameterValue(lipSyncId, value, 0.8f);
-            }
-        }
-
-        // Pose Setting
-        if (pose != null) {
-            pose.updateParameters(model, deltaTimeSeconds);
-        }
+        // 各種パラメーターの更新（まばたき・表情・ドラッグ追従・呼吸・物理・ポーズなど）
+        updateScheduler.onLateUpdate(model, deltaTimeSeconds);
 
         model.update();
     }
@@ -467,6 +436,8 @@ public class LAppModel extends CubismUserModel {
                         expressions.put(name, motion);
                     }
                 }
+
+                updateScheduler.addUpdatableList(new CubismExpressionUpdater(expressionManager));
             }
         }
 
@@ -479,6 +450,9 @@ public class LAppModel extends CubismUserModel {
 
                 loadPhysics(buffer);
             }
+            if (physics != null) {
+                updateScheduler.addUpdatableList(new CubismPhysicsUpdater(physics));
+            }
         }
 
         // Pose
@@ -489,11 +463,23 @@ public class LAppModel extends CubismUserModel {
                 byte[] buffer = createBuffer(modelPath);
                 loadPose(buffer);
             }
+            if (pose != null) {
+                updateScheduler.addUpdatableList(new CubismPoseUpdater(pose));
+            }
         }
 
         // Load eye blink data
         if (modelSetting.getEyeBlinkParameterCount() > 0) {
             eyeBlink = CubismEyeBlink.create(modelSetting);
+
+            // Use an anonymous IBooleanSupplier implementation
+            // so the updater needs to see the latest motionUpdated value on each frame.
+            updateScheduler.addUpdatableList(new CubismEyeBlinkUpdater(new IBooleanSupplier() {
+                @Override
+                public boolean getAsBoolean() {
+                    return motionUpdated;
+                }
+            }, eyeBlink));
         }
 
         // Load Breath Data
@@ -508,6 +494,8 @@ public class LAppModel extends CubismUserModel {
 
         breath.setParameters(breathParameters);
 
+        updateScheduler.addUpdatableList(new CubismBreathUpdater(breath));
+
         // Load UserData
         {
             String path = modelSetting.getUserDataFile();
@@ -518,6 +506,24 @@ public class LAppModel extends CubismUserModel {
             }
         }
 
+        // Look
+        {
+            look = CubismLook.create();
+
+            List<CubismLook.LookParameterData> lookParameters = new ArrayList<>();
+            lookParameters.add(new CubismLook.LookParameterData(idParamAngleX, 30.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamAngleY, 0.0f, 30.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamAngleZ, 0.0f, 0.0f, -30.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamBodyAngleX, 10.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamEyeBallX, 1.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamEyeBallY, 0.0f, 1.0f));
+
+            look.setParameters(lookParameters);
+
+            updateScheduler.addUpdatableList(new CubismLookUpdater(look, dragManager));
+        }
+
+        updateScheduler.sortUpdatableList();
 
         // EyeBlinkIds
         int eyeBlinkIdCount = modelSetting.getEyeBlinkParameterCount();
@@ -687,6 +693,10 @@ public class LAppModel extends CubismUserModel {
      * パラメーターID: ParamEyeBallY
      */
     private final CubismId idParamEyeBallY;
+    /**
+     * 現フレームでメインモーションがパラメーターを更新したか
+     */
+    private boolean motionUpdated;
 
     /**
      * フレームバッファ以外の描画先

--- a/Sample/src/full/java/com/live2d/demo/full/LAppTextureManager.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppTextureManager.java
@@ -48,8 +48,11 @@ public class LAppTextureManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        // decodeStreamは乗算済みアルファとして画像を読み込むようである
-        Bitmap bitmap = BitmapFactory.decodeStream(stream);
+        
+        // LAppDefineで設定された乗算済みアルファの設定に従って画像を読み込む
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inPremultiplied = LAppDefine.PREMULTIPLIED_ALPHA_ENABLE;
+        Bitmap bitmap = BitmapFactory.decodeStream(stream, null, options);
 
         // Texture0をアクティブにする
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
@@ -87,6 +90,13 @@ public class LAppTextureManager {
         }
 
         return textureInfo;
+    }
+
+    /**
+     * 無効になったテクスチャ情報を破棄する。GLコンテキストが破棄された場合に呼び出す。
+     */
+    public void releaseInvalidTextures() {
+        textures.clear();
     }
 
     private final List<TextureInfo> textures = new ArrayList<TextureInfo>();        // 画像情報のリスト

--- a/Sample/src/full/java/com/live2d/demo/full/LAppView.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppView.java
@@ -37,7 +37,18 @@ public class LAppView implements AutoCloseable {
 
     @Override
     public void close() {
-        spriteShader.close();
+        renderingBuffer.destroyRenderTarget();
+
+        renderingSprite = null;
+
+        if (spriteShader != null) {
+            spriteShader.close();
+            spriteShader = null;
+        }
+
+        backSprite = null;
+        gearSprite = null;
+        powerSprite = null;
     }
 
     // ビューを初期化する
@@ -203,7 +214,7 @@ public class LAppView implements AutoCloseable {
      * @param refModel モデルデータ
      */
     public void preModelDraw(LAppModel refModel) {
-        // 別のレンダリングターゲットへ向けて描画する場合の使用するオフスクリーンサーフェス
+        // 別のレンダリングターゲットへ向けて描画する場合の使用するレンダーターゲット
         CubismRenderTargetAndroid useTarget;
 
         // 透過設定
@@ -361,7 +372,7 @@ public class LAppView implements AutoCloseable {
         // 論理座標変換した座標を取得
         float screenY = deviceToScreen.transformY(deviceY);
         // 拡大、縮小、移動後の値
-        return viewMatrix.invertTransformX(screenY);
+        return viewMatrix.invertTransformY(screenY);
     }
 
     /**
@@ -381,7 +392,7 @@ public class LAppView implements AutoCloseable {
      * @return ScreenY座標
      */
     public float transformScreenY(float deviceY) {
-        return deviceToScreen.transformX(deviceY);
+        return deviceToScreen.transformY(deviceY);
     }
 
     /**

--- a/Sample/src/full/java/com/live2d/demo/full/LAppWavFileHandler.java
+++ b/Sample/src/full/java/com/live2d/demo/full/LAppWavFileHandler.java
@@ -17,9 +17,11 @@ import android.media.MediaExtractor;
 import android.media.MediaFormat;
 import android.os.Build;
 
+import com.live2d.sdk.cubism.framework.motion.IParameterProvider;
+
 import java.io.IOException;
 
-public class LAppWavFileHandler extends Thread {
+public class LAppWavFileHandler extends Thread implements IParameterProvider {
     public LAppWavFileHandler(String filePath) {
         this.filePath = filePath;
     }
@@ -73,6 +75,24 @@ public class LAppWavFileHandler extends Thread {
         int offset = 100;
         byte[] voiceBuffer = LAppPal.loadFileAsBytes(filePath);
         audioTrack.write(voiceBuffer, offset, voiceBuffer.length - offset);
+    }
+
+    @Override
+    public boolean update() {
+        return false;
+    }
+
+    @Override
+    public boolean update(float deltaTimeSeconds) {
+        return false;
+    }
+
+    @Override
+    public float getParameter() {
+        // Lip sync is not implemented in this sample.
+        // To enable lip sync, compute the RMS from the audio buffer
+        // and return a normalized value (e.g. [0, 1]).
+        return 0.0f;
     }
 
     private final String filePath;

--- a/Sample/src/full/java/com/live2d/demo/full/MainActivity.java
+++ b/Sample/src/full/java/com/live2d/demo/full/MainActivity.java
@@ -7,16 +7,19 @@
 
 package com.live2d.demo.full;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.opengl.GLSurfaceView;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.WindowInsets;
-import android.view.WindowInsetsController;
+
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 public class MainActivity extends Activity {
+    @SuppressLint("ClickableViewAccessibility")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -28,23 +31,50 @@ public class MainActivity extends Activity {
 
         glSurfaceView.setRenderer(glRenderer);
         glSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_CONTINUOUSLY);
+        glSurfaceView.setPreserveEGLContextOnPause(true);
 
         setContentView(glSurfaceView);
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-            );
-        } else {
-            getWindow().getInsetsController().hide(WindowInsets.Type.navigationBars() | WindowInsets.Type.statusBars());
+        // GLSurfaceViewでタッチイベントを処理する
+        glSurfaceView.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View view, final MotionEvent event) {
+                final float pointX = event.getX();
+                final float pointY = event.getY();
+                glSurfaceView.queueEvent(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            switch (event.getAction()) {
+                                case MotionEvent.ACTION_DOWN:
+                                    LAppDelegate.getInstance().onTouchBegan(pointX, pointY);
+                                    break;
+                                case MotionEvent.ACTION_UP:
+                                    LAppDelegate.getInstance().onTouchEnd(pointX, pointY);
+                                    break;
+                                case MotionEvent.ACTION_MOVE:
+                                    LAppDelegate.getInstance().onTouchMoved(pointX, pointY);
+                                    break;
+                            }
+                        }
+                    }
+                );
+                return true;
+            }
+        });
 
-            getWindow().getInsetsController().setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        // システムバーの表示制御を行うコントローラーを取得する
+        insetsController = WindowCompat.getInsetsController(
+            getWindow(),
+            getWindow().getDecorView()
+        );
+
+        if (insetsController != null) {
+            // スワイプで一時表示し、自動で再び隠す（没入モード）
+            insetsController.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
         }
+
+        hideSystemBars();
     }
 
     @Override
@@ -61,15 +91,7 @@ public class MainActivity extends Activity {
 
         glSurfaceView.onResume();
 
-        View decor = this.getWindow().getDecorView();
-        decor.setSystemUiVisibility(
-            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-        );
+        hideSystemBars();
     }
 
     @Override
@@ -95,33 +117,21 @@ public class MainActivity extends Activity {
 
     }
 
-    @Override
-    public boolean onTouchEvent(final MotionEvent event) {
-        final float pointX = event.getX();
-        final float pointY = event.getY();
-
-        // GLSurfaceViewのイベント処理キューにタッチイベントを追加する。
-        glSurfaceView.queueEvent(
-            new Runnable() {
-                @Override
-                public void run() {
-                    switch (event.getAction()) {
-                        case MotionEvent.ACTION_DOWN:
-                            LAppDelegate.getInstance().onTouchBegan(pointX, pointY);
-                            break;
-                        case MotionEvent.ACTION_UP:
-                            LAppDelegate.getInstance().onTouchEnd(pointX, pointY);
-                            break;
-                        case MotionEvent.ACTION_MOVE:
-                            LAppDelegate.getInstance().onTouchMoved(pointX, pointY);
-                            break;
-                    }
-                }
-            }
+    /**
+     * Hide the system bars (status bar and navigation bar).
+     */
+    private void hideSystemBars() {
+        insetsController.hide(
+            WindowInsetsCompat.Type.navigationBars()
+            | WindowInsetsCompat.Type.statusBars()
         );
-        return super.onTouchEvent(event);
     }
 
     private GLSurfaceView glSurfaceView;
     private GLRenderer glRenderer;
+
+    /**
+     * Reused across lifecycle methods to preserve bar behavior settings.
+     */
+    private WindowInsetsControllerCompat insetsController;
 }

--- a/Sample/src/minimum/AndroidManifest.xml
+++ b/Sample/src/minimum/AndroidManifest.xml
@@ -14,7 +14,7 @@
     android:theme="@android:style/Theme.NoTitleBar">
     <activity
       android:name=".minimum.MainActivityMinimum"
-      android:configChanges="orientation|screenSize"
+      android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
       android:screenOrientation="fullUser"
       android:exported="true">
       <intent-filter>

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumDelegate.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumDelegate.java
@@ -12,6 +12,7 @@ import android.opengl.GLES20;
 import android.os.Build;
 import com.live2d.demo.LAppDefine;
 import com.live2d.sdk.cubism.framework.CubismFramework;
+import com.live2d.sdk.cubism.framework.rendering.android.CubismShaderAndroid;
 
 import static android.opengl.GLES20.*;
 
@@ -33,14 +34,13 @@ public class LAppMinimumDelegate {
     }
 
     public void onStart(Activity activity) {
-        textureManager = new LAppMinimumTextureManager();
-        view = new LAppMinimumView();
-
-        LAppMinimumPal.updateTime();
         this.activity = activity;
+        isActive = true;
     }
 
-    public void onStop() {
+    public void onStop() {}
+
+    public void onDestroy() {
         if (view != null) {
             view.close();
         }
@@ -48,9 +48,7 @@ public class LAppMinimumDelegate {
 
         LAppMinimumLive2DManager.releaseInstance();
         CubismFramework.dispose();
-    }
 
-    public void onDestroy() {
         releaseInstance();
     }
 
@@ -63,8 +61,31 @@ public class LAppMinimumDelegate {
         GLES20.glEnable(GLES20.GL_BLEND);
         GLES20.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-        // Initialize Cubism SDK framework
-        CubismFramework.initialize();
+        if (textureManager == null) {
+            textureManager = new LAppMinimumTextureManager();
+        } else {
+            // 無効になっているテクスチャ情報を破棄
+            textureManager.releaseInvalidTextures();
+        }
+
+        if (view != null) {
+            view.close();
+        }
+        view = new LAppMinimumView();
+
+        LAppMinimumPal.updateTime();
+
+        if (!CubismFramework.isInitialized()) {
+            CubismFramework.initialize();
+        }
+
+        // 無効になっているOpenGLリソースを破棄
+        CubismShaderAndroid.getInstance().releaseInvalidShaderProgram();
+        // シェーダコードを再読み込みするためにインスタンスを破棄しておく
+        CubismShaderAndroid.deleteInstance();
+
+        LAppMinimumLive2DManager live2DManager = LAppMinimumLive2DManager.getInstance();
+        live2DManager.getModel(0).reloadRenderer();
     }
 
     public void onSurfaceChanged(int width, int height) {
@@ -79,8 +100,6 @@ public class LAppMinimumDelegate {
 
         // オフスクリーンのサイズ変更
         LAppMinimumLive2DManager.getInstance().setRenderTargetSize(width, height);
-
-        isActive = true;
     }
 
     public void run() {

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumModel.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumModel.java
@@ -12,6 +12,7 @@ import com.live2d.sdk.cubism.framework.CubismDefaultParameterId;
 import com.live2d.sdk.cubism.framework.CubismFramework;
 import com.live2d.sdk.cubism.framework.CubismModelSettingJson;
 import com.live2d.sdk.cubism.framework.ICubismModelSetting;
+import com.live2d.sdk.cubism.framework.effect.CubismLook;
 import com.live2d.sdk.cubism.framework.id.CubismId;
 import com.live2d.sdk.cubism.framework.id.CubismIdManager;
 import com.live2d.sdk.cubism.framework.math.CubismMatrix44;
@@ -19,7 +20,11 @@ import com.live2d.sdk.cubism.framework.model.CubismMoc;
 import com.live2d.sdk.cubism.framework.model.CubismUserModel;
 import com.live2d.sdk.cubism.framework.motion.ACubismMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotion;
+import com.live2d.sdk.cubism.framework.motion.CubismExpressionUpdater;
+import com.live2d.sdk.cubism.framework.motion.CubismLookUpdater;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
+import com.live2d.sdk.cubism.framework.motion.CubismPhysicsUpdater;
+import com.live2d.sdk.cubism.framework.motion.CubismPoseUpdater;
 import com.live2d.sdk.cubism.framework.motion.IBeganMotionCallback;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
 import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
@@ -71,6 +76,21 @@ public class LAppMinimumModel extends CubismUserModel {
     }
 
     /**
+     * レンダラとテクスチャを再構築する。GLコンテキストが破棄された場合に呼び出す。
+     */
+    public void reloadRenderer() {
+        deleteRenderer();
+
+        CubismRenderer renderer = CubismRendererAndroid.create(
+            LAppMinimumDelegate.getInstance().getWindowWidth(),
+            LAppMinimumDelegate.getInstance().getWindowHeight()
+        );
+        setupRenderer(renderer);
+
+        setupTextures();
+    }
+
+    /**
      * モデルの更新処理。モデルのパラメーターから描画状態を決定する
      */
     public void update() {
@@ -79,10 +99,8 @@ public class LAppMinimumModel extends CubismUserModel {
         final float deltaTimeSeconds = LAppMinimumPal.getDeltaTime();
         _userTimeSeconds += deltaTimeSeconds;
 
-        dragManager.update(deltaTimeSeconds);
-
         // モーションによるパラメーター更新の有無
-        boolean isMotionUpdated = false;
+        motionUpdated = false;
 
         // 前回セーブされた状態をロード
         model.loadParameters();
@@ -92,56 +110,14 @@ public class LAppMinimumModel extends CubismUserModel {
             startMotion(LAppDefine.MotionGroup.IDLE.getId(), 0, LAppDefine.Priority.IDLE.getPriority());
         } else {
             // モーションを更新
-            isMotionUpdated = motionManager.updateMotion(model, deltaTimeSeconds);
+            motionUpdated = motionManager.updateMotion(model, deltaTimeSeconds);
         }
 
         // モデルの状態を保存
         model.saveParameters();
 
-        // eye blink
-        // メインモーションの更新がないときだけまばたきする
-        if (!isMotionUpdated) {
-            if (eyeBlink != null) {
-                eyeBlink.updateParameters(model, deltaTimeSeconds);
-            }
-        }
-
-        // expression
-        // 表情でパラメータ更新（相対変化）
-        if (expressionManager != null) {
-            expressionManager.updateMotion(model, deltaTimeSeconds);
-        }
-
-        // ドラッグ追従機能
-        // ドラッグによる顔の向きの調整
-        float dragX = dragManager.getX();
-        float dragY = dragManager.getY();
-
-        model.addParameterValue(idParamAngleX, dragX * 30); // -30から30の値を加える
-        model.addParameterValue(idParamAngleY, dragY * 30);
-        model.addParameterValue(idParamAngleZ, dragX * dragY * (-30));
-
-        // ドラッグによる体の向きの調整
-        model.addParameterValue(idParamBodyAngleX, dragX * 10); // -10から10の値を加える
-
-        // ドラッグによる目の向きの調整
-        model.addParameterValue(idParamEyeBallX, dragX);  // -1から1の値を加える
-        model.addParameterValue(idParamEyeBallY, dragY);
-
-        // Breath Function
-        if (breath != null) {
-            breath.updateParameters(model, deltaTimeSeconds);
-        }
-
-        // Physics Setting
-        if (physics != null) {
-            physics.evaluate(model, deltaTimeSeconds);
-        }
-
-        // Pose Setting
-        if (pose != null) {
-            pose.updateParameters(model, deltaTimeSeconds);
-        }
+        // 各種パラメーターの更新（表情・物理・ポーズ・ドラッグ追従など）
+        updateScheduler.onLateUpdate(model, deltaTimeSeconds);
 
         model.update();
 
@@ -295,17 +271,8 @@ public class LAppMinimumModel extends CubismUserModel {
 
                 expressions.put(name, motion);
             }
-        }
 
-        // Physics
-        {
-            String path = this.modelSetting.getPhysicsFileName();
-            if (!path.equals("")) {
-                String modelPath = modelHomeDirectory + path;
-                byte[] buffer = LAppMinimumPal.loadFileAsBytes(modelPath);
-
-                loadPhysics(buffer);
-            }
+            updateScheduler.addUpdatableList(new CubismExpressionUpdater(expressionManager));
         }
 
         // Pose
@@ -317,6 +284,23 @@ public class LAppMinimumModel extends CubismUserModel {
                 byte[] buffer = LAppMinimumPal.loadFileAsBytes(modelPath);
 
                 loadPose(buffer);
+            }
+            if (pose != null) {
+                updateScheduler.addUpdatableList(new CubismPoseUpdater(pose));
+            }
+        }
+
+        // Physics
+        {
+            String path = this.modelSetting.getPhysicsFileName();
+            if (!path.equals("")) {
+                String modelPath = modelHomeDirectory + path;
+                byte[] buffer = LAppMinimumPal.loadFileAsBytes(modelPath);
+
+                loadPhysics(buffer);
+            }
+            if (physics != null) {
+                updateScheduler.addUpdatableList(new CubismPhysicsUpdater(physics));
             }
         }
 
@@ -330,6 +314,25 @@ public class LAppMinimumModel extends CubismUserModel {
                 loadUserData(buffer);
             }
         }
+
+        // Look
+        {
+            look = CubismLook.create();
+
+            List<CubismLook.LookParameterData> lookParameters = new ArrayList<CubismLook.LookParameterData>();
+            lookParameters.add(new CubismLook.LookParameterData(idParamAngleX, 30.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamAngleY, 0.0f, 30.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamAngleZ, 0.0f, 0.0f, -30.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamBodyAngleX, 10.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamEyeBallX, 1.0f));
+            lookParameters.add(new CubismLook.LookParameterData(idParamEyeBallY, 0.0f, 1.0f));
+
+            look.setParameters(lookParameters);
+
+            updateScheduler.addUpdatableList(new CubismLookUpdater(look, dragManager));
+        }
+
+        updateScheduler.sortUpdatableList();
 
 
         // Set layout
@@ -423,8 +426,11 @@ public class LAppMinimumModel extends CubismUserModel {
 
             ((CubismRendererAndroid) getRenderer()).bindTexture(modelTextureNumber, glTextureNumber);
 
-            // AndroidのdecodeStreamメソッドで読む場合は恐らく乗算済みアルファとなる。
-            this.<CubismRendererAndroid>getRenderer().isPremultipliedAlpha(true);
+            if (LAppDefine.PREMULTIPLIED_ALPHA_ENABLE) {
+                this.<CubismRendererAndroid>getRenderer().isPremultipliedAlpha(true);
+            } else {
+                this.<CubismRendererAndroid>getRenderer().isPremultipliedAlpha(false);
+            }
         }
     }
 
@@ -473,6 +479,11 @@ public class LAppMinimumModel extends CubismUserModel {
      * パラメーターID: ParamEyeBallY
      */
     private final CubismId idParamEyeBallY;
+    /**
+     * 現フレームでメインモーションがパラメーターを更新したか
+     */
+    private boolean motionUpdated;
+
     /**
      * フレームバッファ以外の描画先
      */

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumTextureManager.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumTextureManager.java
@@ -12,6 +12,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.opengl.GLES20;
 import android.opengl.GLUtils;
+import com.live2d.demo.LAppDefine;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,8 +47,11 @@ public class LAppMinimumTextureManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        // decodeStreamは乗算済みアルファとして画像を読み込むようである
-        Bitmap bitmap = BitmapFactory.decodeStream(stream);
+        
+        // LAppDefineで設定された乗算済みアルファの設定に従って画像を読み込む
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inPremultiplied = LAppDefine.PREMULTIPLIED_ALPHA_ENABLE;
+        Bitmap bitmap = BitmapFactory.decodeStream(stream, null, options);
 
         // Texture0をアクティブにする
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
@@ -79,6 +83,13 @@ public class LAppMinimumTextureManager {
         bitmap.recycle();
 
         return textureInfo;
+    }
+
+    /**
+     * 無効になったテクスチャ情報を破棄する。GLコンテキストが破棄された場合に呼び出す。
+     */
+    public void releaseInvalidTextures() {
+        textures.clear();
     }
 
     private final List<TextureInfo> textures = new ArrayList<TextureInfo>();        // 画像情報のリスト

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumView.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/LAppMinimumView.java
@@ -32,7 +32,14 @@ public class LAppMinimumView implements AutoCloseable {
 
     @Override
     public void close() {
-        spriteShader.close();
+        renderingBuffer.destroyRenderTarget();
+
+        renderingSprite = null;
+
+        if (spriteShader != null) {
+            spriteShader.close();
+            spriteShader = null;
+        }
     }
 
     // ビューを初期化する
@@ -129,7 +136,7 @@ public class LAppMinimumView implements AutoCloseable {
      * @param refModel モデルデータ
      */
     public void preModelDraw(LAppMinimumModel refModel) {
-        // 別のレンダリングターゲットへ向けて描画する場合の使用するオフスクリーンサーフェス
+        // 別のレンダリングターゲットへ向けて描画する場合の使用するレンダーターゲット
         CubismRenderTargetAndroid useTarget;
 
         // 別のレンダリングターゲットへ向けて描画する場合
@@ -267,7 +274,7 @@ public class LAppMinimumView implements AutoCloseable {
         // 論理座標変換した座標を取得
         float screenY = deviceToScreen.transformY(deviceY);
         // 拡大、縮小、移動後の値
-        return viewMatrix.invertTransformX(screenY);
+        return viewMatrix.invertTransformY(screenY);
     }
 
     /**

--- a/Sample/src/minimum/java/com.live2d.demo.minimum/MainActivityMinimum.java
+++ b/Sample/src/minimum/java/com.live2d.demo.minimum/MainActivityMinimum.java
@@ -7,14 +7,19 @@
 
 package com.live2d.demo.minimum;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.opengl.GLSurfaceView;
 import android.os.Bundle;
 import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 public class MainActivityMinimum extends Activity {
-    private GLSurfaceView _glSurfaceView;
-
+    @SuppressLint("ClickableViewAccessibility")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -26,8 +31,51 @@ public class MainActivityMinimum extends Activity {
 
         _glSurfaceView.setRenderer(_glRenderer);
         _glSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_CONTINUOUSLY);
+        _glSurfaceView.setPreserveEGLContextOnPause(true);
 
         setContentView(_glSurfaceView);
+
+        // システムバーの表示制御を行うコントローラーを取得する
+        insetsController = WindowCompat.getInsetsController(
+            getWindow(),
+            getWindow().getDecorView()
+        );
+
+        if (insetsController != null) {
+            // スワイプで一時表示し、自動で再び隠す（没入モード）
+            insetsController.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        }
+
+        hideSystemBars();
+
+        _glSurfaceView.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View view, final MotionEvent event) {
+                final float pointX = event.getX();
+                final float pointY = event.getY();
+
+                // GLSurfaceViewのイベント処理キューにタッチイベントを追加する。
+                _glSurfaceView.queueEvent(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            switch (event.getAction()) {
+                                case MotionEvent.ACTION_DOWN:
+                                    LAppMinimumDelegate.getInstance().onTouchBegan(pointX, pointY);
+                                    break;
+                                case MotionEvent.ACTION_UP:
+                                    LAppMinimumDelegate.getInstance().onTouchEnd(pointX, pointY);
+                                    break;
+                                case MotionEvent.ACTION_MOVE:
+                                    LAppMinimumDelegate.getInstance().onTouchMoved(pointX, pointY);
+                                    break;
+                            }
+                        }
+                    }
+                );
+                return true;
+            }
+        });
     }
 
     @Override
@@ -41,6 +89,8 @@ public class MainActivityMinimum extends Activity {
     protected void onResume() {
         super.onResume();
         _glSurfaceView.onResume();
+
+        hideSystemBars();
     }
 
     @Override
@@ -63,30 +113,20 @@ public class MainActivityMinimum extends Activity {
         LAppMinimumDelegate.getInstance().onDestroy();
     }
 
-    @Override
-    public boolean onTouchEvent(final MotionEvent event) {
-        final float pointX = event.getX();
-        final float pointY = event.getY();
-
-        // GLSurfaceViewのイベント処理キューにタッチイベントを追加する。
-        _glSurfaceView.queueEvent(
-            new Runnable() {
-                @Override
-                public void run() {
-                    switch (event.getAction()) {
-                        case MotionEvent.ACTION_DOWN:
-                            LAppMinimumDelegate.getInstance().onTouchBegan(pointX, pointY);
-                            break;
-                        case MotionEvent.ACTION_UP:
-                            LAppMinimumDelegate.getInstance().onTouchEnd(pointX, pointY);
-                            break;
-                        case MotionEvent.ACTION_MOVE:
-                            LAppMinimumDelegate.getInstance().onTouchMoved(pointX, pointY);
-                            break;
-                    }
-                }
-            }
+    /**
+     * Hide the system bars (status bar and navigation bar).
+     */
+    private void hideSystemBars() {
+        insetsController.hide(
+            WindowInsetsCompat.Type.navigationBars()
+            | WindowInsetsCompat.Type.statusBars()
         );
-        return super.onTouchEvent(event);
     }
+
+    private GLSurfaceView _glSurfaceView;
+
+    /**
+     * Reused across lifecycle methods to preserve bar behavior settings.
+     */
+    private WindowInsetsControllerCompat insetsController;
 }


### PR DESCRIPTION
### Changed

* Migrate system bar hiding in `MainActivity` and `MainActivityMinimum` classes from deprecated `setSystemUiVisibility()` to `WindowInsetsControllerCompat`.
* Reorganize lifecycle methods in the `LAppDelegate` and `LAppMinimumDelegate` classes to reliably reconstruct rendering resources on GL surface recreation.
* Change motion calculation order in `LAppModel` and `LAppMinimumModel` classes to be performed by `CubismUpdateScheduler` class with per-feature Updaters.
* Change `LAppModel` and `LAppMinimumModel` classes to configure parameter IDs and settings for target tracking via `CubismLook` class.
* Change `LAppWavFileHandler` class to implement the `IParameterProvider` interface.

### Fixed

* Fix collision detection misalignment in split-screen mode.
* Fix app state reset when entering split-screen mode.
* Fix the model being clipped by system bars in the Minimum sample app on Android 15 or later.
* Fix an issue in the Android sample where shaders were rebuilt every time the app returned to the foreground.
* Unify remaining uses of `OffscreenSurface` in comments to `RenderTarget`.
* Fix missing resource release in `close()` method of the `LAppView` and `LAppMinimumView` classes.
* Fix incorrect debug log output when tapping the body hit area of the model.
* Fix the bug where Y-axis coordinate transform methods incorrectly used X-axis methods in the `LAppView` and `LAppMinimumView` classes.
* Fix an issue where `PREMULTIPLIED_ALPHA_ENABLE` flag was not applied to texture loading in the `LAppTextureManager` and `LAppMinimumTextureManager` classes.
* Fix an issue where `PREMULTIPLIED_ALPHA_ENABLE` flag was not referenced for renderer premultiplied alpha setting in the `LAppMinimumModel` class.